### PR TITLE
Fix nil panic in postgresql/result.go

### DIFF
--- a/postgresql/database_test.go
+++ b/postgresql/database_test.go
@@ -159,6 +159,28 @@ func TestTruncate(t *testing.T) {
 	}
 }
 
+func TestSetCursorError(t *testing.T) {
+	sess, err := db.Open(wrapperName, settings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sess.Close()
+
+	artist, err := sess.Collection("artist")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// trigger Postgres error. "" is not an int.
+	res := artist.Find(db.Cond{"id": ""})
+
+	var row map[string]interface{}
+	err = res.One(&row)
+	if err == db.ErrNoMoreRows || err == nil {
+		t.Fatalf("err = %#v, want PQ error", err)
+	}
+}
+
 // This test appends some data into the "artist" table.
 func TestAppend(t *testing.T) {
 

--- a/postgresql/result.go
+++ b/postgresql/result.go
@@ -147,24 +147,19 @@ func (self *Result) One(dst interface{}) error {
 
 // Fetches the next result from the resultset.
 func (self *Result) Next(dst interface{}) error {
-
-	var err error
-
-	// Current cursor.
-	err = self.setCursor()
-
+	err := self.setCursor()
 	if err != nil {
 		self.Close()
+		return err
 	}
 
-	// Fetching the next result from the cursor.
 	err = self.table.T.FetchRow(dst, self.cursor)
-
 	if err != nil {
 		self.Close()
+		return err
 	}
 
-	return err
+	return nil
 }
 
 // Removes the matching items from the collection.


### PR DESCRIPTION
SQL errors from CursorQuery() were unhandled in Next(). Caused nil panic when using Collection.One and db.Cond was invalid. Fixed by handling errors.
