### PR TITLE
Save time zones in postgres driver

### DIFF
--- a/postgresql/database.go
+++ b/postgresql/database.go
@@ -38,7 +38,7 @@ const Adapter = `postgresql`
 
 var (
 	// Format for saving dates.
-	DateFormat = "2006-01-02 15:04:05"
+	DateFormat = "2006-01-02 15:04:05.999999999 MST"
 	// Format for saving times.
 	TimeFormat = "%d:%02d:%02d.%d"
 	SSLMode    = "disable"


### PR DESCRIPTION
The current format doesn't save the time stamp, which leads to undefined behavior when updating a TIMESTAMP WITH TIME ZONE column.
