### PR TITLE
Make inserting data into MongoDB with an _id possible

### DIFF
--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -292,9 +292,9 @@ func toNative(val interface{}) interface{} {
 }
 
 var (
-	// fieldCache should be a struct if we're going to cache more than just _id field here
-	fieldCache      = make(map[reflect.Type]string, 0)
-	fieldCacheMutex sync.RWMutex
+	// idCache should be a struct if we're going to cache more than just _id field here
+	idCache      = make(map[reflect.Type]string, 0)
+	idCacheMutex sync.RWMutex
 )
 
 // Fetches object _id or generates a new one if object doesn't have one or the one it has is invalid
@@ -314,9 +314,9 @@ func getId(item interface{}) bson.ObjectId {
 	case reflect.Struct:
 		t := v.Type()
 
-		fieldCacheMutex.RLock()
-		fieldName, found := fieldCache[t]
-		fieldCacheMutex.RUnlock()
+		idCacheMutex.RLock()
+		fieldName, found := idCache[t]
+		idCacheMutex.RUnlock()
 
 		if !found {
 			for n := 0; n < t.NumField(); n++ {
@@ -338,9 +338,9 @@ func getId(item interface{}) bson.ObjectId {
 
 				if parts[0] == "_id" {
 					fieldName = field.Name
-					fieldCacheMutex.RLock()
-					fieldCache[t] = fieldName
-					fieldCacheMutex.RUnlock()
+					idCacheMutex.RLock()
+					idCache[t] = fieldName
+					idCacheMutex.RUnlock()
 					break
 				}
 			}

--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -226,21 +226,6 @@ func (self *Collection) Append(item interface{}) (interface{}, error) {
 	}
 
 	return id, nil
-
-	/*
-		var id bson.ObjectId
-		var err error
-
-		id = bson.NewObjectId()
-
-		_, err = self.collection.Upsert(bson.M{"_id": id}, item);
-
-		if err != nil {
-			return nil, err
-		}
-
-		return id, nil
-	*/
 }
 
 // Returns true if the collection exists.

--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -277,9 +277,9 @@ func toNative(val interface{}) interface{} {
 
 // Fetches object _id or generates a new one if object doesn't have one or the one it has is invalid
 func getId(item interface{}) bson.ObjectId {
-	i := reflect.TypeOf(item)
+	v := reflect.ValueOf(item)
 
-	switch i.Kind() {
+	switch v.Kind() {
 	case reflect.Map:
 		if inItem, ok := item.(map[string]interface{}); ok {
 			if id, ok := inItem["_id"]; ok {
@@ -290,8 +290,9 @@ func getId(item interface{}) bson.ObjectId {
 			}
 		}
 	case reflect.Struct:
-		for n := 0; n < i.NumField(); n++ {
-			field := i.Field(n)
+		t := v.Type()
+		for n := 0; n < t.NumField(); n++ {
+			field := t.Field(n)
 			if field.PkgPath != "" {
 				continue // Private field
 			}
@@ -308,8 +309,7 @@ func getId(item interface{}) bson.ObjectId {
 			parts := strings.Split(tag, ",")
 
 			if parts[0] == "_id" {
-				vi := reflect.ValueOf(item)
-				if bsonId, ok := vi.FieldByName(field.Name).Interface().(bson.ObjectId); ok {
+				if bsonId, ok := v.FieldByName(field.Name).Interface().(bson.ObjectId); ok {
 					return bsonId
 				}
 			}

--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -207,7 +207,6 @@ func (self *Collection) Append(item interface{}) (interface{}, error) {
 	var err error
 
 	id := getId(item)
-
 	// this breaks MongoDb older than 2.6
 	if _, err = self.collection.Upsert(bson.M{"_id": id}, item); err != nil {
 		return nil, err

--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -227,6 +227,8 @@ func (self *Collection) Append(item interface{}) (interface{}, error) {
 
 		// Now append data the user wants to append.
 		if err = self.collection.Update(bson.M{"_id": id}, item); err != nil {
+			// Cleanup allocated ID
+			self.collection.Remove(bson.M{"_id": id})
 			return nil, err
 		}
 	}

--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -323,7 +323,9 @@ func getId(item interface{}) bson.ObjectId {
 
 				if parts[0] == "_id" {
 					fieldName = field.Name
+					fieldCacheMutex.RLock()
 					fieldCache[t] = fieldName
+					fieldCacheMutex.RUnlock()
 					break
 				}
 			}

--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -209,12 +209,7 @@ func (self *Collection) Append(item interface{}) (interface{}, error) {
 
 	id := getId(item)
 
-	buildInfo, err := self.collection.Database.Session.BuildInfo()
-	if err != nil {
-		return nil, err
-	}
-
-	if buildInfo.VersionAtLeast(2, 6, 0, 0) {
+	if self.parent.VersionAtLeast(2, 6, 0, 0) {
 		// this breaks MongoDb older than 2.6
 		if _, err = self.collection.Upsert(bson.M{"_id": id}, item); err != nil {
 			return nil, err

--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -207,13 +207,7 @@ func (self *Collection) Append(item interface{}) (interface{}, error) {
 
 	id = bson.NewObjectId()
 
-	// Allocating a new ID.
-	if err = self.collection.Insert(bson.M{"_id": id}); err != nil {
-		return nil, err
-	}
-
-	// Now append data the user wants to append.
-	if err = self.collection.Update(bson.M{"_id": id}, item); err != nil {
+	if _, err = self.collection.Upsert(bson.M{"_id": id}, item); err != nil {
 		return nil, err
 	}
 

--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -347,7 +347,9 @@ func getId(item interface{}) bson.ObjectId {
 		}
 		if fieldName != "" {
 			if bsonId, ok := v.FieldByName(fieldName).Interface().(bson.ObjectId); ok {
-				return bsonId
+				if bsonId.Valid() {
+					return bsonId
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Right now it is impossible to insert something into Mongo collection with a specific _id, because one is always generated before appending resulting in an error.

This pull request also cherry picks the reverted commit that switched mongo db adapter to use upsert instead of insert then update. ~~This is only supported by Mongo 2.6+, but it reduces the number of db writes on insert by 50%..~~ I have updated the code to use Upsert with MongoDB 2.6+ and fall back to the old method otherwise. I've also added cleanup code that fixes #58.