### PR TITLE
Removing gosexy on the postgresql wrapper, the need for flags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-#  - 1.1 // ql fails to compile on go1.2+.
+#  - 1.1 // Unsupported, QL fails to compile on go < 1.2.
   - 1.2
   - 1.2.1
   - 1.2.2
@@ -10,9 +10,12 @@ go:
   - 1.3.2
   - 1.3.3
   - 1.4
+  - 1.4.1
+  - 1.4.2
 
 env:
   - GOARCH=amd64
+  - TEST_HOST=127.0.0.1
 
 install:
   - sudo apt-get install bzr
@@ -38,4 +41,4 @@ before_script:
 
 script:
   - go version
-  - go test -host 127.0.0.1
+  - go test

--- a/postgresql/connection.go
+++ b/postgresql/connection.go
@@ -167,8 +167,15 @@ func ParseURL(s string) (u ConnectionURL, err error) {
 
 	u.Database = o.Get("dbname")
 
-	u.Options = map[string]string{
-		"sslmode": o.Get("sslmode"),
+	u.Options = make(map[string]string)
+
+	for k := range o {
+		switch k {
+		case "user", "password", "host", "port", "dbname":
+			// Skip
+		default:
+			u.Options[k] = o[k]
+		}
 	}
 
 	return u, err

--- a/postgresql/connection_test.go
+++ b/postgresql/connection_test.go
@@ -156,4 +156,22 @@ func TestParseConnectionURL(t *testing.T) {
 	if u.Options["sslmode"] != "verify-full" {
 		t.Fatal("Failed to parse SSLMode.")
 	}
+
+	s = "user=anakin password=skywalker host=localhost dbname=jedis sslmode=verify-full timezone=UTC"
+
+	if u, err = ParseURL(s); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(u.Options) != 2 {
+		t.Fatal("Expecting exactly two options.")
+	}
+
+	if u.Options["sslmode"] != "verify-full" {
+		t.Fatal("Failed to parse SSLMode.")
+	}
+
+	if u.Options["timezone"] != "UTC" {
+		t.Fatal("Failed to parse timezone.")
+	}
 }

--- a/postgresql/database.go
+++ b/postgresql/database.go
@@ -31,7 +31,7 @@ import (
 
 	"github.com/jmoiron/sqlx"
 	"github.com/jmoiron/sqlx/reflectx"
-	_ "github.com/lib/pq"
+	_ "github.com/lib/pq" // PostgreSQL driver.
 	"upper.io/cache"
 	"upper.io/db"
 	"upper.io/db/util/schema"
@@ -121,13 +121,12 @@ func (s *source) Open() error {
 }
 
 // Return a struct tag mapper
-func (a *source) mapper() *reflectx.Mapper {
+func (s *source) mapper() *reflectx.Mapper {
 	m := reflectx.NewMapperTagFunc("db", strings.ToLower, func(value string) string {
 		if strings.Contains(value, ",") {
 			return strings.Split(value, ",")[0]
-		} else {
-			return value
 		}
+		return value
 	})
 	return m
 }

--- a/postgresql/database_test.go
+++ b/postgresql/database_test.go
@@ -46,10 +46,17 @@ const (
 	password = "upperio"
 )
 
+const (
+	testTimeZone = "Canada/Eastern"
+)
+
 var settings = ConnectionURL{
 	Database: database,
 	User:     username,
 	Password: password,
+	Options: map[string]string{
+		"timezone": testTimeZone,
+	},
 }
 
 var host string
@@ -122,7 +129,7 @@ func (item *itemWithKey) SetID(keys map[string]interface{}) error {
 var testValues testValuesStruct
 
 func init() {
-	loc, err := time.LoadLocation("Canada/Eastern")
+	loc, err := time.LoadLocation(testTimeZone)
 
 	if err != nil {
 		panic(err.Error())

--- a/postgresql/result.go
+++ b/postgresql/result.go
@@ -92,6 +92,7 @@ func (r *result) Group(fields ...interface{}) db.Result {
 	groupByColumns := make(sqlgen.GroupBy, 0, len(fields))
 
 	l := len(fields)
+
 	for i := 0; i < l; i++ {
 		switch value := fields[i].(type) {
 		// Maybe other types?
@@ -217,14 +218,14 @@ func (r *result) One(dst interface{}) error {
 }
 
 // Fetches the next result from the resultset.
-func (r *result) Next(dst interface{}) error {
-	err := r.setCursor()
-	if err != nil {
+func (r *result) Next(dst interface{}) (err error) {
+
+	if err = r.setCursor(); err != nil {
 		r.Close()
 		return err
 	}
 
-	if err := sqlutil.FetchRow(r.cursor, dst); err != nil {
+	if err = sqlutil.FetchRow(r.cursor, dst); err != nil {
 		r.Close()
 		return err
 	}
@@ -235,11 +236,13 @@ func (r *result) Next(dst interface{}) error {
 // Removes the matching items from the collection.
 func (r *result) Remove() error {
 	var err error
+
 	_, err = r.table.source.doExec(sqlgen.Statement{
 		Type:  sqlgen.SqlDelete,
 		Table: sqlgen.Table{r.table.Name()},
 		Where: r.where,
 	}, r.arguments...)
+
 	return err
 
 }
@@ -274,8 +277,7 @@ func (r *result) Update(values interface{}) error {
 }
 
 // Closes the result set.
-func (r *result) Close() error {
-	var err error
+func (r *result) Close() (err error) {
 	if r.cursor != nil {
 		err = r.cursor.Close()
 		r.cursor = nil


### PR DESCRIPTION
This commit removes `gosexy/to` from the `postgresql` wrapper and adds some minor (cosmetic) source code changes.

Testing flags were removed too, if you want to change the database(s) server(s) you'll need to provide an environment variable something like this:

```
TEST_HOST=testserver.local UPPERIO_DB_DEBUG=1 go test 
```