### PR TITLE
Benchmark SQLite performance against prepared statements

### DIFF
--- a/sqlite/database_test.go
+++ b/sqlite/database_test.go
@@ -1380,8 +1380,13 @@ func BenchmarkAppendRawSQL(b *testing.B) {
 	}
 
 	b.ResetTimer()
+	stmt, err := driver.Prepare(
+		`INSERT INTO "artist" ("name") VALUES('Hayao Miyazaki')`)
+	if err != nil {
+		b.Fatal(err)
+	}
 	for i := 0; i < b.N; i++ {
-		if _, err = driver.Exec(`INSERT INTO "artist" ("name") VALUES('Hayao Miyazaki')`); err != nil {
+		if _, err = stmt.Exec(); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -1438,8 +1443,13 @@ func BenchmarkAppendTxRawSQL(b *testing.B) {
 	}
 
 	b.ResetTimer()
+	stmt, err := tx.Prepare(
+		`INSERT INTO "artist" ("name") VALUES('Hayao Miyazaki')`)
+	if err != nil {
+		b.Fatal(err)
+	}
 	for i := 0; i < b.N; i++ {
-		if _, err = tx.Exec(`INSERT INTO "artist" ("name") VALUES('Hayao Miyazaki')`); err != nil {
+		if _, err = stmt.Exec(); err != nil {
 			b.Fatal(err)
 		}
 	}


### PR DESCRIPTION
I was benchmarking db to see if it could replace some "raw" SQLite code that I have, and I found that your existing benchmarks don't reflect optimal SQLite usage because they don't use prepared statements (nor does any part of the code seem to do that). I added them to the benchmarks, and got the following results. Before:

```
BenchmarkAppendRawSQL	     100	  14886563 ns/op
BenchmarkAppendUpper	     100	  15604206 ns/op
BenchmarkAppendTxRawSQL	  200000	      6672 ns/op
BenchmarkAppendTxUpper	  100000	     22329 ns/op
BenchmarkAppendTxUpperMap	   50000	     24342 ns/op
```

After:

```
BenchmarkAppendRawSQL	     100	  13728325 ns/op
BenchmarkAppendUpper	     100	  15739658 ns/op
BenchmarkAppendTxRawSQL	  500000	      3447 ns/op
BenchmarkAppendTxUpper	  100000	     22208 ns/op
BenchmarkAppendTxUpperMap	   50000	     26936 ns/op
```

This shows that the performance gap between db and raw SQL is actually a factor two worse than the original benchmarks showed...