### PR TITLE
Prepare and cache queries in SQLite

### DIFF
--- a/sqlite/database_test.go
+++ b/sqlite/database_test.go
@@ -1169,7 +1169,7 @@ func TestTransactionsAndRollback(t *testing.T) {
 	}
 
 	if count != 1 {
-		t.Fatalf("Expecting only one element.")
+		t.Fatalf("Expecting only one element, got %d.", count)
 	}
 
 	// Attempt to add some rows.


### PR DESCRIPTION
Follow-up to #85. Benchmark time is now:

```
BenchmarkAppendTxUpper	  100000	     16965 ns/op
BenchmarkAppendTxUpperMap	  100000	     20500 ns/op
```

Down from:

```
BenchmarkAppendTxUpper	   50000	     34819 ns/op
BenchmarkAppendTxUpperMap	   50000	     38273 ns/op
```

I tried to cache the `sqlgen.Statement` instead of recomputing that too, but for some reason it didn't work (even when I did the comparison with `reflect.DeepEqual`).