### PR TITLE
Issue 57 - Provide Driver() method for SQL database transactions.

### DIFF
--- a/mysql/database.go
+++ b/mysql/database.go
@@ -49,11 +49,6 @@ type database struct {
 	cachedStatements *cache.Cache
 }
 
-type tx struct {
-	*sqltx.Tx
-	*database
-}
-
 type cachedStatement struct {
 	*sqlx.Stmt
 	query string
@@ -357,7 +352,7 @@ func (d *database) Transaction() (db.Tx, error) {
 
 	clone.tx = sqltx.New(sqlTx)
 
-	return tx{Tx: clone.tx, database: clone}, nil
+	return &tx{Tx: clone.tx, database: clone}, nil
 }
 
 // Exec compiles and executes a statement that does not return any rows.

--- a/mysql/database_test.go
+++ b/mysql/database_test.go
@@ -25,7 +25,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"log"
 	"math/rand"
 	"os"
 	"reflect"
@@ -617,7 +616,6 @@ func TestResultFetch(t *testing.T) {
 		}
 
 		if err == nil {
-			log.Println("rowMap[id]:", rowMap["id"], reflect.TypeOf(rowMap["id"]))
 			if pk, ok := rowMap["id"].(int64); !ok || pk == 0 {
 				t.Fatalf("Expecting a not null ID.")
 			}
@@ -1301,6 +1299,12 @@ func TestTransactionsAndRollback(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Won't fail
+	sqlxTx := tx.Driver().(*sqlx.Tx)
+	if _, err = sqlxTx.Exec("INSERT INTO `artist` (`id`, `name`) VALUES(?, ?)", 4, "Fourth"); err != nil {
+		t.Fatal(err)
+	}
+
 	if err = tx.Commit(); err != nil {
 		t.Fatal(err)
 	}
@@ -1309,7 +1313,7 @@ func TestTransactionsAndRollback(t *testing.T) {
 		t.Fatalf("Should have failed, as we've already commited.")
 	}
 
-	// Let's verify we have 3 rows.
+	// Let's verify we have 4 rows.
 	if artist, err = sess.Collection("artist"); err != nil {
 		t.Fatal(err)
 	}
@@ -1318,8 +1322,8 @@ func TestTransactionsAndRollback(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if count != 3 {
-		t.Fatalf("Expecting 3 elements.")
+	if count != 4 {
+		t.Fatalf("Expecting exactly 4 results.")
 	}
 
 }

--- a/mysql/tx.go
+++ b/mysql/tx.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2012-2015 The upper.io/db authors. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package mysql
+
+import (
+	"upper.io/db/util/sqlutil/tx"
+)
+
+type tx struct {
+	*sqltx.Tx
+	*database
+}
+
+// Driver returns the current transaction session.
+func (t *tx) Driver() interface{} {
+	if t != nil && t.Tx != nil {
+		return t.Tx.Tx
+	}
+	return nil
+}

--- a/postgresql/database.go
+++ b/postgresql/database.go
@@ -50,11 +50,6 @@ type database struct {
 	cachedStatements *cache.Cache
 }
 
-type tx struct {
-	*sqltx.Tx
-	*database
-}
-
 type cachedStatement struct {
 	*sqlx.Stmt
 	query string
@@ -348,7 +343,7 @@ func (d *database) Transaction() (db.Tx, error) {
 
 	clone.tx = sqltx.New(sqlTx)
 
-	return tx{Tx: clone.tx, database: clone}, nil
+	return &tx{Tx: clone.tx, database: clone}, nil
 }
 
 // Exec compiles and executes a statement that does not return any rows.

--- a/postgresql/database_test.go
+++ b/postgresql/database_test.go
@@ -1495,6 +1495,12 @@ func TestTransactionsAndRollback(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Won't fail
+	sqlTx := tx.Driver().(*sqlx.Tx)
+	if _, err = sqlTx.Exec(`INSERT INTO "artist" ("id", "name") VALUES($1, $2)`, 4, "Fourth"); err != nil {
+		t.Fatal(err)
+	}
+
 	if err = tx.Commit(); err != nil {
 		t.Fatal(err)
 	}
@@ -1503,7 +1509,7 @@ func TestTransactionsAndRollback(t *testing.T) {
 		t.Fatalf("Should have failed, as we've already commited.")
 	}
 
-	// Let's verify we have 3 rows.
+	// Let's verify we have 4 rows.
 	if artist, err = sess.Collection("artist"); err != nil {
 		t.Fatal(err)
 	}
@@ -1512,8 +1518,8 @@ func TestTransactionsAndRollback(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if count != 3 {
-		t.Fatalf("Expecting only one element.")
+	if count != 4 {
+		t.Fatalf("Expecting exactly 4 results.")
 	}
 
 }

--- a/postgresql/tx.go
+++ b/postgresql/tx.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2012-2015 The upper.io/db authors. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package postgresql
+
+import (
+	"upper.io/db/util/sqlutil/tx"
+)
+
+type tx struct {
+	*sqltx.Tx
+	*database
+}
+
+// Driver returns the current transaction session.
+func (t *tx) Driver() interface{} {
+	if t != nil && t.Tx != nil {
+		return t.Tx.Tx
+	}
+	return nil
+}

--- a/ql/database.go
+++ b/ql/database.go
@@ -50,11 +50,6 @@ type database struct {
 	cachedStatements *cache.Cache
 }
 
-type tx struct {
-	*sqltx.Tx
-	*database
-}
-
 type cachedStatement struct {
 	*sqlx.Stmt
 	query string
@@ -333,7 +328,7 @@ func (d *database) Transaction() (db.Tx, error) {
 
 	clone.tx = sqltx.New(sqlTx)
 
-	return tx{Tx: clone.tx, database: clone}, nil
+	return &tx{Tx: clone.tx, database: clone}, nil
 }
 
 // Exec compiles and executes a statement that does not return any rows.

--- a/ql/database_test.go
+++ b/ql/database_test.go
@@ -1123,6 +1123,12 @@ func TestTransactionsAndRollback(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Won't fail
+	sqlxTx := tx.Driver().(*sqlx.Tx)
+	if _, err = sqlxTx.Exec(`INSERT INTO artist (name) VALUES($1)`, "Fourth"); err != nil {
+		t.Fatal(err)
+	}
+
 	if err = tx.Commit(); err != nil {
 		t.Fatal(err)
 	}
@@ -1131,7 +1137,7 @@ func TestTransactionsAndRollback(t *testing.T) {
 		t.Fatalf("Should have failed, as we've already commited.")
 	}
 
-	// Let's verify we have 3 rows.
+	// Let's verify we have 4 rows.
 	if artist, err = sess.Collection("artist"); err != nil {
 		t.Fatal(err)
 	}
@@ -1140,8 +1146,8 @@ func TestTransactionsAndRollback(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if count != 3 {
-		t.Fatalf("Expecting only one element.")
+	if count != 4 {
+		t.Fatalf("Expecting exactly 4 results.")
 	}
 
 }

--- a/ql/tx.go
+++ b/ql/tx.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2012-2015 The upper.io/db authors. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package ql
+
+import (
+	"upper.io/db/util/sqlutil/tx"
+)
+
+type tx struct {
+	*sqltx.Tx
+	*database
+}
+
+// Driver returns the current transaction session.
+func (t *tx) Driver() interface{} {
+	if t != nil && t.Tx != nil {
+		return t.Tx.Tx
+	}
+	return nil
+}

--- a/sqlite/database.go
+++ b/sqlite/database.go
@@ -54,11 +54,6 @@ type database struct {
 	cachedStatements *cache.Cache
 }
 
-type tx struct {
-	*sqltx.Tx
-	*database
-}
-
 type cachedStatement struct {
 	*sqlx.Stmt
 	query string
@@ -340,7 +335,7 @@ func (d *database) Transaction() (db.Tx, error) {
 
 	clone.tx = sqltx.New(sqlTx)
 
-	return tx{Tx: clone.tx, database: clone}, nil
+	return &tx{Tx: clone.tx, database: clone}, nil
 }
 
 // Exec compiles and executes a statement that does not return any rows.

--- a/sqlite/database_test.go
+++ b/sqlite/database_test.go
@@ -1230,6 +1230,12 @@ func TestTransactionsAndRollback(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Won't fail
+	sqlxTx := tx.Driver().(*sqlx.Tx)
+	if _, err = sqlxTx.Exec(`INSERT INTO "artist" ("id", "name") VALUES(?, ?)`, 4, "Fourth"); err != nil {
+		t.Fatal(err)
+	}
+
 	if err = tx.Commit(); err != nil {
 		t.Fatal(err)
 	}
@@ -1238,7 +1244,7 @@ func TestTransactionsAndRollback(t *testing.T) {
 		t.Fatalf("Should have failed, as we've already commited.")
 	}
 
-	// Let's verify we have 3 rows.
+	// Let's verify we have 4 rows.
 	if artist, err = sess.Collection("artist"); err != nil {
 		t.Fatal(err)
 	}
@@ -1247,8 +1253,8 @@ func TestTransactionsAndRollback(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if count != 3 {
-		t.Fatalf("Expecting 3 elements.")
+	if count != 4 {
+		t.Fatalf("Expecting exactly 4 results.")
 	}
 
 }

--- a/sqlite/tx.go
+++ b/sqlite/tx.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2012-2015 The upper.io/db authors. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package sqlite
+
+import (
+	"upper.io/db/util/sqlutil/tx"
+)
+
+type tx struct {
+	*sqltx.Tx
+	*database
+}
+
+// Driver returns the current transaction session.
+func (t *tx) Driver() interface{} {
+	if t != nil && t.Tx != nil {
+		return t.Tx.Tx
+	}
+	return nil
+}


### PR DESCRIPTION
In #57, @gima noted that currently you can't execute SQL queries within a transaction block because the underlying `*sql.Tx` is not exposed. This change makes possible to get the `*sql.Tx` with the aid of the `Driver()` method:

```go
  if tx, err = sess.Transaction(); err != nil {
    t.Fatal(err)
  }

  if artist, err = tx.Collection("artist"); err != nil {
    t.Fatal(err)
  }

  if _, err = artist.Append(artistT{Name: "Third"}); err != nil {
    t.Fatal(err)
  }

  sqlxTx := tx.Driver().(*sqlx.Tx)
  if _, err = sqlxTx.Exec(`INSERT INTO artist (name) VALUES($1)`, "Fourth"); err != nil {
    t.Fatal(err)
  }

  if err = tx.Commit(); err != nil {
    t.Fatal(err)
  }
```

Using `Driver()` was possible because the `db.Tx` [satisfies](https://github.com/upper/db/blob/issue-57/db.go#L230) the `db.Database` interface.

I think this could be confusing because the `Driver()` method from a database session that is returned by `db.Open()` will return `*sqlx.DB`, while `*sql.Tx` will only be returned by the `Driver()` method of a *session within a transaction* (`sess.Transaction()`).

Or maybe that's not that confusing? they are two different structs after all.