### PR TITLE
Issue 103 - prepareStatement() must return the generated query

### DIFF
--- a/mysql/database.go
+++ b/mysql/database.go
@@ -89,7 +89,7 @@ func (d *database) prepareStatement(stmt *sqlgen.Statement) (p *sqlx.Stmt, query
 		}
 
 		if err != nil {
-			return nil, "", err
+			return nil, query, err
 		}
 
 		d.cachedStatements.Write(stmt, &cachedStatement{p, query})

--- a/postgresql/database.go
+++ b/postgresql/database.go
@@ -91,7 +91,7 @@ func (d *database) prepareStatement(stmt *sqlgen.Statement) (p *sqlx.Stmt, query
 		}
 
 		if err != nil {
-			return nil, "", err
+			return nil, query, err
 		}
 
 		d.cachedStatements.Write(stmt, &cachedStatement{p, query})

--- a/ql/database.go
+++ b/ql/database.go
@@ -90,7 +90,7 @@ func (d *database) prepareStatement(stmt *sqlgen.Statement) (p *sqlx.Stmt, query
 		}
 
 		if err != nil {
-			return nil, "", err
+			return nil, query, err
 		}
 
 		d.cachedStatements.Write(stmt, &cachedStatement{p, query})

--- a/sqlite/database.go
+++ b/sqlite/database.go
@@ -95,7 +95,7 @@ func (d *database) prepareStatement(stmt *sqlgen.Statement) (p *sqlx.Stmt, query
 		}
 
 		if err != nil {
-			return nil, "", err
+			return nil, query, err
 		}
 
 		d.cachedStatements.Write(stmt, &cachedStatement{p, query})


### PR DESCRIPTION
This is for debugging purposes even if the query contains a syntax error.

Closes #103