### PR TITLE
Adding rollback before closing

### DIFF
--- a/mysql/benchmark_test.go
+++ b/mysql/benchmark_test.go
@@ -324,6 +324,7 @@ func BenchmarkUpperAppendTransaction(b *testing.B) {
 	if tx, err = sess.Transaction(); err != nil {
 		b.Fatal(err)
 	}
+	defer tx.Close()
 
 	var artist db.Collection
 	if artist, err = tx.Collection("artist"); err != nil {
@@ -366,6 +367,7 @@ func BenchmarkUpperAppendTransactionWithMap(b *testing.B) {
 	if tx, err = sess.Transaction(); err != nil {
 		b.Fatal(err)
 	}
+	defer tx.Close()
 
 	var artist db.Collection
 	if artist, err = tx.Collection("artist"); err != nil {
@@ -766,6 +768,8 @@ func BenchmarkUpperCommitManyTransactions(b *testing.B) {
 		if err = tx.Commit(); err != nil {
 			b.Fatal(err)
 		}
+
+		tx.Close()
 	}
 }
 
@@ -808,5 +812,7 @@ func BenchmarkUpperRollbackManyTransactions(b *testing.B) {
 		if err = tx.Rollback(); err != nil {
 			b.Fatal(err)
 		}
+
+		tx.Close()
 	}
 }

--- a/mysql/database.go
+++ b/mysql/database.go
@@ -201,6 +201,9 @@ func (d *database) Ping() error {
 // Close terminates the current database session.
 func (d *database) Close() error {
 	if d.session != nil {
+		if d.tx != nil && !d.tx.Done() {
+			d.tx.Rollback()
+		}
 		d.cachedStatements.Clear()
 		return d.session.Close()
 	}

--- a/mysql/database_test.go
+++ b/mysql/database_test.go
@@ -1478,8 +1478,8 @@ func TestExhaustConnections(t *testing.T) {
 			// lasts 3 seconds.
 			time.Sleep(time.Second * 3)
 
-			if err := tx.Rollback(); err != nil {
-				panic(err.Error())
+			if err := tx.Close(); err != nil {
+				t.Fatal(err)
 			}
 
 			t.Logf("Tx %d: Done", i)

--- a/mysql/database_test.go
+++ b/mysql/database_test.go
@@ -1194,6 +1194,8 @@ func TestTransactionsAndRollback(t *testing.T) {
 		t.Fatalf("Illegal, transaction has already been commited.")
 	}
 
+	tx.Close()
+
 	// Use another transaction.
 	if tx, err = sess.Transaction(); err != nil {
 		t.Fatal(err)
@@ -1240,6 +1242,8 @@ func TestTransactionsAndRollback(t *testing.T) {
 		t.Fatalf("Expecting only one element.")
 	}
 
+	tx.Close()
+
 	// Attempt to add some rows.
 	if tx, err = sess.Transaction(); err != nil {
 		t.Fatal(err)
@@ -1280,6 +1284,8 @@ func TestTransactionsAndRollback(t *testing.T) {
 	if count != 1 {
 		t.Fatalf("Expecting only one element.")
 	}
+
+	tx.Close()
 
 	// Attempt to add some rows.
 	if tx, err = sess.Transaction(); err != nil {

--- a/mysql/tx.go
+++ b/mysql/tx.go
@@ -43,7 +43,6 @@ func (t *tx) Commit() error {
 	if err := t.Tx.Commit(); err != nil {
 		return err
 	}
-	t.database.Close()
 	return nil
 }
 
@@ -52,6 +51,5 @@ func (t *tx) Rollback() error {
 	if err := t.Tx.Rollback(); err != nil {
 		return err
 	}
-	t.database.Close()
 	return nil
 }

--- a/mysql/tx.go
+++ b/mysql/tx.go
@@ -38,7 +38,7 @@ func (t *tx) Driver() interface{} {
 	return nil
 }
 
-// Commit commits the current transaction and frees up the connection.
+// Commit commits the current transaction.
 func (t *tx) Commit() error {
 	if err := t.Tx.Commit(); err != nil {
 		return err
@@ -46,7 +46,7 @@ func (t *tx) Commit() error {
 	return nil
 }
 
-// Rollback discards the current transaction and frees up the connection.
+// Rollback discards the current transaction.
 func (t *tx) Rollback() error {
 	if err := t.Tx.Rollback(); err != nil {
 		return err

--- a/postgresql/benchmark_test.go
+++ b/postgresql/benchmark_test.go
@@ -336,6 +336,7 @@ func BenchmarkUpperAppendTransaction(b *testing.B) {
 	if tx, err = sess.Transaction(); err != nil {
 		b.Fatal(err)
 	}
+	defer tx.Close()
 
 	var artist db.Collection
 	if artist, err = tx.Collection("artist"); err != nil {
@@ -378,6 +379,7 @@ func BenchmarkUpperAppendTransactionWithMap(b *testing.B) {
 	if tx, err = sess.Transaction(); err != nil {
 		b.Fatal(err)
 	}
+	defer tx.Close()
 
 	var artist db.Collection
 	if artist, err = tx.Collection("artist"); err != nil {
@@ -778,6 +780,8 @@ func BenchmarkUpperCommitManyTransactions(b *testing.B) {
 		if err = tx.Commit(); err != nil {
 			b.Fatal(err)
 		}
+
+		tx.Close()
 	}
 }
 
@@ -820,5 +824,7 @@ func BenchmarkUpperRollbackManyTransactions(b *testing.B) {
 		if err = tx.Rollback(); err != nil {
 			b.Fatal(err)
 		}
+
+		tx.Close()
 	}
 }

--- a/postgresql/database.go
+++ b/postgresql/database.go
@@ -191,6 +191,9 @@ func (d *database) Ping() error {
 // Close terminates the current database session.
 func (d *database) Close() error {
 	if d.session != nil {
+		if d.tx != nil && !d.tx.Done() {
+			d.tx.Rollback()
+		}
 		d.cachedStatements.Clear()
 		return d.session.Close()
 	}

--- a/postgresql/database_test.go
+++ b/postgresql/database_test.go
@@ -1390,6 +1390,8 @@ func TestTransactionsAndRollback(t *testing.T) {
 		t.Fatalf("Illegal, transaction has already been commited.")
 	}
 
+	tx.Close()
+
 	// Use another transaction.
 	if tx, err = sess.Transaction(); err != nil {
 		t.Fatal(err)
@@ -1436,6 +1438,8 @@ func TestTransactionsAndRollback(t *testing.T) {
 		t.Fatalf("Expecting only one element.")
 	}
 
+	tx.Close()
+
 	// Attempt to add some rows.
 	if tx, err = sess.Transaction(); err != nil {
 		t.Fatal(err)
@@ -1476,6 +1480,8 @@ func TestTransactionsAndRollback(t *testing.T) {
 	if count != 1 {
 		t.Fatalf("Expecting only one element.")
 	}
+
+	tx.Close()
 
 	// Attempt to add some rows.
 	if tx, err = sess.Transaction(); err != nil {

--- a/postgresql/database_test.go
+++ b/postgresql/database_test.go
@@ -1948,7 +1948,7 @@ func TestExhaustConnections(t *testing.T) {
 			// lasts 3 seconds.
 			time.Sleep(time.Second * 3)
 
-			if err := tx.Rollback(); err != nil {
+			if err := tx.Close(); err != nil {
 				t.Fatal(err)
 			}
 

--- a/postgresql/tx.go
+++ b/postgresql/tx.go
@@ -38,20 +38,18 @@ func (t *tx) Driver() interface{} {
 	return nil
 }
 
-// Commit commits the current transaction and frees up the connection.
+// Commit commits the current transaction.
 func (t *tx) Commit() error {
 	if err := t.Tx.Commit(); err != nil {
 		return err
 	}
-	t.database.Close()
 	return nil
 }
 
-// Rollback discards the current transaction and frees up the connection.
+// Rollback discards the current transaction.
 func (t *tx) Rollback() error {
 	if err := t.Tx.Rollback(); err != nil {
 		return err
 	}
-	t.database.Close()
 	return nil
 }

--- a/ql/benchmark_test.go
+++ b/ql/benchmark_test.go
@@ -402,6 +402,7 @@ func BenchmarkUpperAppendTransaction(b *testing.B) {
 	if tx, err = sess.Transaction(); err != nil {
 		b.Fatal(err)
 	}
+	defer tx.Close()
 
 	var artist db.Collection
 	if artist, err = tx.Collection("artist"); err != nil {
@@ -444,6 +445,7 @@ func BenchmarkUpperAppendTransactionWithMap(b *testing.B) {
 	if tx, err = sess.Transaction(); err != nil {
 		b.Fatal(err)
 	}
+	defer tx.Close()
 
 	var artist db.Collection
 	if artist, err = tx.Collection("artist"); err != nil {
@@ -873,6 +875,8 @@ func BenchmarkUpperCommitManyTransactions(b *testing.B) {
 		if err = tx.Commit(); err != nil {
 			b.Fatal(err)
 		}
+
+		tx.Close()
 	}
 }
 
@@ -915,5 +919,7 @@ func BenchmarkUpperRollbackManyTransactions(b *testing.B) {
 		if err = tx.Rollback(); err != nil {
 			b.Fatal(err)
 		}
+
+		tx.Close()
 	}
 }

--- a/ql/database_test.go
+++ b/ql/database_test.go
@@ -1304,7 +1304,7 @@ func TestExhaustConnections(t *testing.T) {
 			// We have to use a shorten time here.
 			time.Sleep(time.Millisecond * 500)
 
-			if err := tx.Rollback(); err != nil {
+			if err := tx.Close(); err != nil {
 				panic(err.Error())
 			}
 

--- a/ql/database_test.go
+++ b/ql/database_test.go
@@ -1018,6 +1018,8 @@ func TestTransactionsAndRollback(t *testing.T) {
 		t.Fatalf("Illegal, transaction has already been commited.")
 	}
 
+	tx.Close()
+
 	// Use another transaction.
 	if tx, err = sess.Transaction(); err != nil {
 		t.Fatal(err)
@@ -1064,6 +1066,8 @@ func TestTransactionsAndRollback(t *testing.T) {
 		t.Fatalf("Expecting only one element.")
 	}
 
+	tx.Close()
+
 	// Attempt to add some rows.
 	if tx, err = sess.Transaction(); err != nil {
 		t.Fatal(err)
@@ -1104,6 +1108,8 @@ func TestTransactionsAndRollback(t *testing.T) {
 	if count != 1 {
 		t.Fatalf("Expecting only one element.")
 	}
+
+	tx.Close()
 
 	// Attempt to add some rows.
 	if tx, err = sess.Transaction(); err != nil {

--- a/ql/tx.go
+++ b/ql/tx.go
@@ -38,20 +38,18 @@ func (t *tx) Driver() interface{} {
 	return nil
 }
 
-// Commit commits the current transaction and frees up the connection.
+// Commit commits the current transaction.
 func (t *tx) Commit() error {
 	if err := t.Tx.Commit(); err != nil {
 		return err
 	}
-	t.database.Close()
 	return nil
 }
 
-// Rollback discards the current transaction and frees up the connection.
+// Rollback discards the current transaction.
 func (t *tx) Rollback() error {
 	if err := t.Tx.Rollback(); err != nil {
 		return err
 	}
-	t.database.Close()
 	return nil
 }

--- a/sqlite/benchmark_test.go
+++ b/sqlite/benchmark_test.go
@@ -324,6 +324,7 @@ func BenchmarkUpperAppendTransaction(b *testing.B) {
 	if tx, err = sess.Transaction(); err != nil {
 		b.Fatal(err)
 	}
+	defer tx.Close()
 
 	var artist db.Collection
 	if artist, err = tx.Collection("artist"); err != nil {
@@ -366,6 +367,7 @@ func BenchmarkUpperAppendTransactionWithMap(b *testing.B) {
 	if tx, err = sess.Transaction(); err != nil {
 		b.Fatal(err)
 	}
+	defer tx.Close()
 
 	var artist db.Collection
 	if artist, err = tx.Collection("artist"); err != nil {
@@ -766,6 +768,8 @@ func BenchmarkUpperCommitManyTransactions(b *testing.B) {
 		if err = tx.Commit(); err != nil {
 			b.Fatal(err)
 		}
+
+		tx.Close()
 	}
 }
 
@@ -808,5 +812,7 @@ func BenchmarkUpperRollbackManyTransactions(b *testing.B) {
 		if err = tx.Rollback(); err != nil {
 			b.Fatal(err)
 		}
+
+		tx.Close()
 	}
 }

--- a/sqlite/database_test.go
+++ b/sqlite/database_test.go
@@ -1426,7 +1426,7 @@ func TestExhaustConnections(t *testing.T) {
 			// lasts 3 seconds.
 			time.Sleep(time.Second * 3)
 
-			if err := tx.Rollback(); err != nil {
+			if err := tx.Close(); err != nil {
 				panic(err.Error())
 			}
 

--- a/sqlite/database_test.go
+++ b/sqlite/database_test.go
@@ -1125,6 +1125,8 @@ func TestTransactionsAndRollback(t *testing.T) {
 		t.Fatalf("Illegal, transaction has already been commited.")
 	}
 
+	tx.Close()
+
 	// Use another transaction.
 	if tx, err = sess.Transaction(); err != nil {
 		t.Fatal(err)
@@ -1171,6 +1173,8 @@ func TestTransactionsAndRollback(t *testing.T) {
 		t.Fatalf("Expecting only one element, got %d.", count)
 	}
 
+	tx.Close()
+
 	// Attempt to add some rows.
 	if tx, err = sess.Transaction(); err != nil {
 		t.Fatal(err)
@@ -1211,6 +1215,8 @@ func TestTransactionsAndRollback(t *testing.T) {
 	if count != 1 {
 		t.Fatalf("Expecting only one element.")
 	}
+
+	tx.Close()
 
 	// Attempt to add some rows.
 	if tx, err = sess.Transaction(); err != nil {

--- a/sqlite/tx.go
+++ b/sqlite/tx.go
@@ -38,20 +38,18 @@ func (t *tx) Driver() interface{} {
 	return nil
 }
 
-// Commit commits the current transaction and frees up the connection.
+// Commit commits the current transaction.
 func (t *tx) Commit() error {
 	if err := t.Tx.Commit(); err != nil {
 		return err
 	}
-	t.database.Close()
 	return nil
 }
 
-// Rollback discards the current transaction and frees up the connection.
+// Rollback discards the current transaction.
 func (t *tx) Rollback() error {
 	if err := t.Tx.Rollback(); err != nil {
 		return err
 	}
-	t.database.Close()
 	return nil
 }


### PR DESCRIPTION
Forcing automatic rollback when closing the database session during a transaction. This rollback has no effect after a previous commit or (another) rollback.

See: https://github.com/upper/db/issues/117 and https://github.com/upper/db/pull/109