### PR TITLE
Fixes sqlx.Rows not being closed if table exists

### DIFF
--- a/postgresql/database.go
+++ b/postgresql/database.go
@@ -573,8 +573,10 @@ func (d *database) tableExists(names ...string) error {
 			return db.ErrCollectionDoesNotExist
 		}
 
-		if !rows.Next() {
-			rows.Close()
+		tExists := rows.Next()
+		rows.Close()
+
+		if !tExists {
 			return db.ErrCollectionDoesNotExist
 		}
 	}


### PR DESCRIPTION
`rows` not being closed properly causes db connection to hang until it times out. 

If you find yourself in a situation where `tableExists` is called within a transaction all consecutive operations on a transaction will fail with `pq: unexpected Parse response 'C'`