### PR TITLE
Fixes large transactions causing PostgreSQL server run out of memory

### DIFF
--- a/postgresql/database.go
+++ b/postgresql/database.go
@@ -87,8 +87,13 @@ func (d *database) WithSession(sess interface{}) (db.Database, error) {
 		clone.tx = sqltx.New(tx)
 	}
 
-	clone.cachedStatements = cache.NewCache()
-	clone.collections = make(map[string]*table)
+	d.collectionsMu.Lock()
+	clone.cachedStatements = d.cachedStatements
+	clone.collections = d.collections
+	d.collectionsMu.Unlock()
+	if clone.collections == nil {
+		clone.collections = make(map[string]*table)
+	}
 
 	if clone.schema == nil {
 		if err := clone.populateSchema(); err != nil {


### PR DESCRIPTION
Prepared statements are stored by PostgreSQL server within session context - will not be cleared until session is closed or they are deallocated (see http://www.postgresql.org/docs/9.5/static/sql-deallocate.html ).

By starting with a fresh cache and fresh collections map every single time we use WithSession we start creating duplicate prepared statements. This makes a massive difference:

Example: large transaction (200k INSERTs, each with WithSession):
- Before this change: PostgreSQL server killed by OOM killer when it's memory used exceeded **12 GB** (40% inserts made it into transaction)
- After this change: Max PostgreSQL server memory use: **3.5 GB**
- After this change + https://github.com/upper/cache/pull/3 : Max PostgreSQL server memory use: **0.38 GB**