### PR TITLE
Reinitialize database on Clone()

### DIFF
--- a/mongo/database.go
+++ b/mongo/database.go
@@ -71,11 +71,13 @@ func (s *Source) Setup(connURL db.ConnectionURL) error {
 }
 
 func (s *Source) Clone() (db.Database, error) {
+	newSession := s.session.Copy()
+
 	clone := &Source{
 		name:     s.name,
 		connURL:  s.connURL,
-		session:  s.session.Copy(),
-		database: s.database,
+		session:  newSession,
+		database: newSession.DB(s.database.Name),
 		version:  s.version,
 	}
 	return clone, nil


### PR DESCRIPTION
Our application calls `session.Clone()` on each http request to interact with mongo concurrently. 
However, we noticed two concerning behaviours:

- Our mongo logs showed that only one connection was used at any given time, even if we had hundreds of goroutines requesting something from the database and performance began to decrease
- In case the connection to mongo got corrupted, the application wasn't able to recover by itself. It had to get restarted manually. 

Now, both those things shouldn't happen with mgo when you use `session.Copy()`. But it turns out that [mgo.Database](https://github.com/go-mgo/mgo/blob/v2/session.go#L96) holds its own session for all database calls. So in order to properly refresh a session, we also need to refresh the database object itself.