### PR TITLE
Add NextScan and ScanOne to Iterator

### DIFF
--- a/internal/sqladapter/testing/adapter.go.tpl
+++ b/internal/sqladapter/testing/adapter.go.tpl
@@ -1103,7 +1103,13 @@ func TestBuilder(t *testing.T) {
 	iter = sess.SelectFrom("artist").Iterator()
 	var id int
 	var name string
-	err = iter.NextScan(&id, &name)
+
+	if Adapter == "ql" {
+		err = iter.NextScan(&name)
+		id = 1
+	} else {
+		err = iter.NextScan(&id, &name)
+	}
 
 	assert.NoError(t, err)
 	assert.NotZero(t, id)
@@ -1116,7 +1122,12 @@ func TestBuilder(t *testing.T) {
 	// Using explicit iterator and ScanOne.
 	iter = sess.SelectFrom("artist").Iterator()
 	id, name = 0, ""
-	err = iter.ScanOne(&id, &name)
+	if Adapter == "ql" {
+		err = iter.ScanOne(&name)
+		id = 1
+	} else {
+		err = iter.ScanOne(&id, &name)
+	}
 
 	assert.NoError(t, err)
 	assert.NotZero(t, id)
@@ -1130,7 +1141,9 @@ func TestBuilder(t *testing.T) {
 
 	var artist map[string]interface{}
 	for iter.Next(&artist) {
-		assert.NotZero(t, artist["id"])
+		if Adapter != "ql" {
+			assert.NotZero(t, artist["id"])
+		}
 		assert.NotEmpty(t, artist["name"])
 	}
 	// We should not have any error after finishing successfully exiting a Next() loop.

--- a/internal/sqladapter/testing/adapter.go.tpl
+++ b/internal/sqladapter/testing/adapter.go.tpl
@@ -1099,6 +1099,50 @@ func TestBuilder(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotZero(t, all)
 
+	// Using explicit iterator and NextScan.
+	iter = sess.SelectFrom("artist").Iterator()
+	var id int
+	var name string
+	err = iter.NextScan(&id, &name)
+
+	assert.NoError(t, err)
+	assert.NotZero(t, id)
+	assert.NotEmpty(t, name)
+	assert.NoError(t, iter.Close())
+
+	err = iter.NextScan(&id, &name)
+	assert.Error(t, err)
+
+	// Using explicit iterator and ScanOne.
+	iter = sess.SelectFrom("artist").Iterator()
+	id, name = 0, ""
+	err = iter.ScanOne(&id, &name)
+
+	assert.NoError(t, err)
+	assert.NotZero(t, id)
+	assert.NotEmpty(t, name)
+
+	err = iter.ScanOne(&id, &name)
+	assert.Error(t, err)
+
+	// Using explicit iterator and Next.
+	iter = sess.SelectFrom("artist").Iterator()
+
+	var artist map[string]interface{}
+	for iter.Next(&artist) {
+		assert.NotZero(t, artist["id"])
+		assert.NotEmpty(t, artist["name"])
+	}
+	// We should not have any error after finishing successfully exiting a Next() loop.
+	assert.Empty(t, iter.Err())
+
+	for i := 0; i < 5; i++ {
+		// But we'll get errors if we attempt to continue using Next().
+		assert.False(t, iter.Next(&artist))
+		assert.Error(t, iter.Err())
+	}
+
+
 	// Using implicit iterator.
 	q := sess.SelectFrom("artist")
 	err = q.All(&all)

--- a/lib/sqlbuilder/interfaces.go
+++ b/lib/sqlbuilder/interfaces.go
@@ -416,6 +416,12 @@ type Iterator interface {
 	// Scan dumps the current result into the given pointer variable pointers.
 	Scan(dest ...interface{}) error
 
+	// NextScan advances the iterator and performs Scan.
+	NextScan(dest ...interface{}) error
+
+	// ScanOne advances the iterator, performs Scan and closes the iterator.
+	ScanOne(dest ...interface{}) error
+
 	// Next dumps the current element into the given destination, which could be
 	// a pointer to either a map or a struct.
 	Next(dest ...interface{}) bool


### PR DESCRIPTION
Provides support to handle a couple of common patterns in which the user wants to advance + read, or advance + read + close.