### PR TITLE
fix upper/db#237

### DIFF
--- a/internal/sqladapter/database.go
+++ b/internal/sqladapter/database.go
@@ -187,14 +187,11 @@ func (d *database) Close() error {
 		d.cachedStatements.Clear() // Closes prepared statements as well.
 
 		tx := d.Transaction()
-		if tx == nil {
-			// Not within a transaction.
-			return d.sess.Close()
-		}
-
-		if !tx.Committed() {
+		if tx != nil && !tx.Committed() {
 			tx.Rollback()
 		}
+
+		return d.sess.Close()
 	}
 	return nil
 }

--- a/internal/sqladapter/database.go
+++ b/internal/sqladapter/database.go
@@ -187,11 +187,14 @@ func (d *database) Close() error {
 		d.cachedStatements.Clear() // Closes prepared statements as well.
 
 		tx := d.Transaction()
-		if tx != nil && !tx.Committed() {
-			tx.Rollback()
+		if tx == nil {
+			// Not within a transaction.
+			return d.sess.Close()
 		}
 
-		return d.sess.Close()
+		if !tx.Committed() {
+			tx.Rollback()
+		}
 	}
 	return nil
 }

--- a/sqlite/tx.go
+++ b/sqlite/tx.go
@@ -33,3 +33,15 @@ type tx struct {
 var (
 	_ = db.Tx(&tx{})
 )
+
+func (t *tx) Commit() error {
+	sess := t.Session()
+	defer sess.Close()
+	return t.DatabaseTx.Commit()
+}
+
+func (t *tx) Rollback() error {
+	sess := t.Session()
+	defer sess.Close()
+	return t.DatabaseTx.Rollback()
+}

--- a/sqlite/tx.go
+++ b/sqlite/tx.go
@@ -35,13 +35,15 @@ var (
 )
 
 func (t *tx) Commit() error {
-	sess := t.Session()
-	defer sess.Close()
+	if sess := t.Session(); sess != nil {
+		defer sess.Close()
+	}
 	return t.DatabaseTx.Commit()
 }
 
 func (t *tx) Rollback() error {
-	sess := t.Session()
-	defer sess.Close()
+	if sess := t.Session(); sess != nil {
+		defer sess.Close()
+	}
 	return t.DatabaseTx.Rollback()
 }


### PR DESCRIPTION
This is a potential fix for #237. Some concerns remain about adapter behavior with regards to `Commit` and `Rollback` of transactions, as this is code that's shared by all SQL adapters.