### PR TITLE
Add test for Where() before Set() on update

### DIFF
--- a/lib/sqlbuilder/builder.go
+++ b/lib/sqlbuilder/builder.go
@@ -530,3 +530,19 @@ var (
 	_ = Builder(&sqlBuilder{})
 	_ = exprDB(&exprProxy{})
 )
+
+func joinArguments(args ...[]interface{}) []interface{} {
+	total := 0
+	for i := range args {
+		total += len(args[i])
+	}
+	if total == 0 {
+		return nil
+	}
+
+	flatten := make([]interface{}, 0, total)
+	for i := range args {
+		flatten = append(flatten, args[i]...)
+	}
+	return flatten
+}

--- a/lib/sqlbuilder/delete.go
+++ b/lib/sqlbuilder/delete.go
@@ -27,6 +27,10 @@ func (qd *deleter) Limit(limit int) Deleter {
 	return qd
 }
 
+func (qd *deleter) Arguments() []interface{} {
+	return qd.arguments
+}
+
 func (qd *deleter) Exec() (sql.Result, error) {
 	return qd.builder.sess.StatementExec(qd.statement(), qd.arguments...)
 }

--- a/lib/sqlbuilder/interfaces.go
+++ b/lib/sqlbuilder/interfaces.go
@@ -365,6 +365,9 @@ type Deleter interface {
 	// fmt.Stringer provides `String() string`, you can use `String()` to compile
 	// the `Inserter` into a string.
 	fmt.Stringer
+
+	// Arguments returns the arguments that are prepared for this query.
+	Arguments() []interface{}
 }
 
 // Updater represents an UPDATE statement.
@@ -388,6 +391,9 @@ type Updater interface {
 	// fmt.Stringer provides `String() string`, you can use `String()` to compile
 	// the `Inserter` into a string.
 	fmt.Stringer
+
+	// Arguments returns the arguments that are prepared for this query.
+	Arguments() []interface{}
 }
 
 // Execer provides methods for executing statements that do not return results.

--- a/lib/sqlbuilder/select.go
+++ b/lib/sqlbuilder/select.go
@@ -121,18 +121,14 @@ func (qs *selector) Arguments() []interface{} {
 	qs.mu.Lock()
 	defer qs.mu.Unlock()
 
-	total := len(qs.tableArgs) + len(qs.columnsArgs) + len(qs.whereArgs) + len(qs.joinsArgs) + len(qs.groupByArgs) + len(qs.orderByArgs)
-	if total == 0 {
-		return nil
-	}
-	args := make([]interface{}, 0, total)
-	args = append(args, qs.tableArgs...)
-	args = append(args, qs.columnsArgs...)
-	args = append(args, qs.joinsArgs...)
-	args = append(args, qs.whereArgs...)
-	args = append(args, qs.groupByArgs...)
-	args = append(args, qs.orderByArgs...)
-	return args
+	return joinArguments(
+		qs.tableArgs,
+		qs.columnsArgs,
+		qs.joinsArgs,
+		qs.whereArgs,
+		qs.groupByArgs,
+		qs.orderByArgs,
+	)
 }
 
 func (qs *selector) GroupBy(columns ...interface{}) Selector {


### PR DESCRIPTION
If `Where()` was used before `Set()` on builder's update, the argument list became unusable. See: https://github.com/upper/db/issues/276
