### PR TITLE
Make prepared statement cache optional (and disabled by default)

### DIFF
--- a/db.go
+++ b/db.go
@@ -489,6 +489,18 @@ type Database interface {
 
 	// ClearCache clears all the cache mechanisms the adapter is using.
 	ClearCache()
+
+	// SetConnMaxLifetime sets the maximum amount of time a connection may be
+	// reused.
+	SetConnMaxLifetime(time.Duration)
+
+	// SetMaxIdleConns sets the maximum number of connections in the idle
+	// connection pool.
+	SetMaxIdleConns(int)
+
+	// SetMaxOpenConns sets the maximum number of open connections to the
+	// database.
+	SetMaxOpenConns(int)
 }
 
 // Tx has methods for transactions that can be either committed or rolled back.

--- a/internal/sqladapter/collection.go
+++ b/internal/sqladapter/collection.go
@@ -3,6 +3,7 @@ package sqladapter
 import (
 	"fmt"
 	"reflect"
+	"sync"
 
 	"upper.io/db.v2"
 	"upper.io/db.v2/internal/sqladapter/exql"
@@ -35,6 +36,7 @@ type BaseCollection interface {
 type collection struct {
 	p  PartialCollection
 	pk []string
+	mu sync.Mutex
 }
 
 // NewBaseCollection returns a collection with basic methods.
@@ -68,6 +70,9 @@ func (c *collection) Exists() bool {
 
 // InsertReturning inserts an item and updates the given variable reference.
 func (c *collection) InsertReturning(item interface{}) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if reflect.TypeOf(item).Kind() != reflect.Ptr {
 		return fmt.Errorf("Expecting a pointer to map or string but got %T", item)
 	}

--- a/internal/sqladapter/collection.go
+++ b/internal/sqladapter/collection.go
@@ -3,7 +3,6 @@ package sqladapter
 import (
 	"fmt"
 	"reflect"
-	"sync"
 
 	"upper.io/db.v2"
 	"upper.io/db.v2/internal/sqladapter/exql"
@@ -36,7 +35,6 @@ type BaseCollection interface {
 type collection struct {
 	p  PartialCollection
 	pk []string
-	mu sync.Mutex
 }
 
 // NewBaseCollection returns a collection with basic methods.
@@ -70,9 +68,6 @@ func (c *collection) Exists() bool {
 
 // InsertReturning inserts an item and updates the given variable reference.
 func (c *collection) InsertReturning(item interface{}) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	if reflect.TypeOf(item).Kind() != reflect.Ptr {
 		return fmt.Errorf("Expecting a pointer to map or string but got %T", item)
 	}

--- a/internal/sqladapter/statement.go
+++ b/internal/sqladapter/statement.go
@@ -3,6 +3,7 @@ package sqladapter
 import (
 	"database/sql"
 	"errors"
+	"sync"
 	"sync/atomic"
 )
 
@@ -10,21 +11,16 @@ var (
 	activeStatements int64
 )
 
-// NumActiveStatements returns the number of prepared statements in use at any
-// point.
-func NumActiveStatements() int64 {
-	return atomic.LoadInt64(&activeStatements)
-}
-
 // Stmt represents a *sql.Stmt that is cached and provides the
 // OnPurge method to allow it to clean after itself.
 type Stmt struct {
 	*sql.Stmt
 
 	query string
+	mu    sync.Mutex
 
 	count int64
-	dead  int32
+	dead  bool
 }
 
 // NewStatement creates an returns an opened statement
@@ -32,44 +28,58 @@ func NewStatement(stmt *sql.Stmt, query string) *Stmt {
 	s := &Stmt{
 		Stmt:  stmt,
 		query: query,
-		count: 1,
 	}
-	// Increment active statements counter.
 	atomic.AddInt64(&activeStatements, 1)
 	return s
 }
 
 // Open marks the statement as in-use
 func (c *Stmt) Open() (*Stmt, error) {
-	if atomic.LoadInt32(&c.dead) > 0 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.dead {
 		return nil, errors.New("statement is dead")
 	}
-	atomic.AddInt64(&c.count, 1)
+
+	c.count++
 	return c, nil
 }
 
 // Close closes the underlying statement if no other go-routine is using it.
-func (c *Stmt) Close() (err error) {
-	if atomic.AddInt64(&c.count, -1) > 0 {
-		// If this counter is more than 0 then there are other goroutines using
-		// this statement so we don't want to close it for real.
-		return
-	}
+func (c *Stmt) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
-	if atomic.LoadInt32(&c.dead) > 0 && atomic.LoadInt64(&c.count) <= 0 {
+	c.count--
+
+	return c.checkClose()
+}
+
+func (c *Stmt) checkClose() error {
+	if c.dead && c.count == 0 {
 		// Statement is dead and we can close it for real.
-		err = c.Stmt.Close()
+		err := c.Stmt.Close()
+		if err != nil {
+			return err
+		}
 		// Reduce active statements counter.
 		atomic.AddInt64(&activeStatements, -1)
 	}
-	return
+	return nil
 }
 
 // OnPurge marks the statement as ready to be cleaned up.
 func (c *Stmt) OnPurge() {
-	// Mark as dead, you can continue using it but it will be closed for real
-	// when c.count reaches 0.
-	atomic.StoreInt32(&c.dead, 1)
-	// Call Close again to make sure we're closing the statement.
-	c.Close()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.dead = true
+	c.checkClose()
+}
+
+// NumActiveStatements returns the global number of prepared statements in use
+// at any point.
+func NumActiveStatements() int64 {
+	return atomic.LoadInt64(&activeStatements)
 }

--- a/mongo/database.go
+++ b/mongo/database.go
@@ -65,6 +65,21 @@ func (s *Source) ConnectionURL() db.ConnectionURL {
 	return s.connURL
 }
 
+// SetConnMaxLifetime is not supported.
+func (s *Source) SetConnMaxLifetime(time.Duration) {
+
+}
+
+// SetMaxIdleConns is not supported.
+func (s *Source) SetMaxIdleConns(int) {
+
+}
+
+// SetMaxOpenConns is not supported.
+func (s *Source) SetMaxOpenConns(int) {
+
+}
+
 // Name returns the name of the database.
 func (s *Source) Name() string {
 	return s.name

--- a/mysql/Makefile
+++ b/mysql/Makefile
@@ -34,4 +34,5 @@ reset-db: require-client
 	mysql -uroot -h"$(DB_HOST)" -P$(DB_PORT) <<< $$SQL
 
 test: reset-db generate
-	go test -tags generated -v -race
+	#go test -tags generated -v -race # race: limit on 8192 simultaneously alive goroutines is exceeded, dying
+	go test -tags generated -v

--- a/mysql/adapter_test.go
+++ b/mysql/adapter_test.go
@@ -164,8 +164,8 @@ func cleanUpCheck(sess sqlbuilder.Database) (err error) {
 		return err
 	}
 
-	if stats["Prepared_stmt_count"] > 128 {
-		return fmt.Errorf(`Expecting "Prepared_stmt_count" not to be greater than the prepared statements cache size (128) before cleaning, got %d`, stats["Prepared_stmt_count"])
+	if activeStatements := sqladapter.NumActiveStatements(); activeStatements > 128 {
+		return fmt.Errorf("Expecting active statements to be at most 128, got %d", activeStatements)
 	}
 
 	sess.ClearCache()

--- a/mysql/database.go
+++ b/mysql/database.go
@@ -133,17 +133,16 @@ func (d *database) clone() (*database, error) {
 		return nil, err
 	}
 
-	clone.BaseDatabase = sqladapter.NewBaseDatabase(clone)
+	clone.BaseDatabase, err = d.BindClone(clone)
+	if err != nil {
+		return nil, err
+	}
 
 	b, err := sqlbuilder.WithSession(clone.BaseDatabase, template)
 	if err != nil {
 		return nil, err
 	}
 	clone.Builder = b
-
-	if err = clone.BaseDatabase.BindSession(d.BaseDatabase.Session()); err != nil {
-		return nil, err
-	}
 
 	return clone, nil
 }

--- a/postgresql/Makefile
+++ b/postgresql/Makefile
@@ -41,4 +41,5 @@ reset-db: require-client
 	fi
 
 test: reset-db generate
-	go test -tags generated -v -race
+	#go test -tags generated -v -race # race: limit on 8192 simultaneously alive goroutines is exceeded, dying
+	go test -tags generated -v

--- a/postgresql/adapter_test.go
+++ b/postgresql/adapter_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"upper.io/db.v2"
+	"upper.io/db.v2/internal/sqladapter"
 	"upper.io/db.v2/lib/sqlbuilder"
 )
 
@@ -362,8 +363,8 @@ func cleanUpCheck(sess sqlbuilder.Database) (err error) {
 		return err
 	}
 
-	if stats["Prepared_stmt_count"] > 128 {
-		return fmt.Errorf(`Expecting "Prepared_stmt_count" not to be greater than the prepared statements cache size (128) before cleaning, got %d`, stats["Prepared_stmt_count"])
+	if activeStatements := sqladapter.NumActiveStatements(); activeStatements > 128 {
+		return fmt.Errorf("Expecting active statements to be at most 128, got %d", activeStatements)
 	}
 
 	sess.ClearCache()

--- a/postgresql/database.go
+++ b/postgresql/database.go
@@ -132,7 +132,10 @@ func (d *database) clone() (*database, error) {
 		return nil, err
 	}
 
-	clone.BaseDatabase = sqladapter.NewBaseDatabase(clone)
+	clone.BaseDatabase, err = d.BindClone(clone)
+	if err != nil {
+		return nil, err
+	}
 
 	b, err := sqlbuilder.WithSession(clone.BaseDatabase, template)
 	if err != nil {
@@ -140,9 +143,6 @@ func (d *database) clone() (*database, error) {
 	}
 	clone.Builder = b
 
-	if err = clone.BaseDatabase.BindSession(d.BaseDatabase.Session()); err != nil {
-		return nil, err
-	}
 	return clone, nil
 }
 

--- a/ql/Makefile
+++ b/ql/Makefile
@@ -22,4 +22,4 @@ reset-db: require-client
 
 test: reset-db generate
 	#go test -tags generated -v -race # race: limit on 8192 simultaneously alive goroutines is exceeded, dying
-	go test -tags generated -v
+	go test -tags generated -timeout 30m -v

--- a/ql/Makefile
+++ b/ql/Makefile
@@ -21,4 +21,5 @@ reset-db: require-client
 	rm -f $(DB_NAME)
 
 test: reset-db generate
+	#go test -tags generated -v -race # race: limit on 8192 simultaneously alive goroutines is exceeded, dying
 	go test -tags generated -v

--- a/ql/database.go
+++ b/ql/database.go
@@ -211,9 +211,16 @@ func (d *database) clone() (*database, error) {
 		return nil, err
 	}
 
-	if err := clone.open(); err != nil {
+	clone.BaseDatabase, err = d.BindClone(clone)
+	if err != nil {
 		return nil, err
 	}
+
+	b, err := sqlbuilder.WithSession(clone.BaseDatabase, template)
+	if err != nil {
+		return nil, err
+	}
+	clone.Builder = b
 
 	return clone, nil
 }
@@ -235,29 +242,25 @@ func (d *database) Err(err error) error {
 }
 
 // StatementExec wraps the statement to execute around a transaction.
-func (d *database) StatementExec(stmt *sql.Stmt, args ...interface{}) (sql.Result, error) {
-	if d.BaseDatabase.Transaction() == nil {
-		var tx *sql.Tx
-		var res sql.Result
-		var err error
-
-		if tx, err = d.Session().Begin(); err != nil {
-			return nil, err
-		}
-
-		s := tx.Stmt(stmt)
-
-		if res, err = s.Exec(args...); err != nil {
-			return nil, err
-		}
-
-		if err = tx.Commit(); err != nil {
-			return nil, err
-		}
-
-		return res, err
+func (d *database) StatementExec(query string, args ...interface{}) (res sql.Result, err error) {
+	if d.Transaction() != nil {
+		return d.Driver().(*sql.Tx).Exec(query, args...)
 	}
-	return stmt.Exec(args...)
+
+	sqlTx, err := d.Session().Begin()
+	if err != nil {
+		return nil, err
+	}
+
+	if res, err = sqlTx.Exec(query, args...); err != nil {
+		return nil, err
+	}
+
+	if err = sqlTx.Commit(); err != nil {
+		return nil, err
+	}
+
+	return res, err
 }
 
 // NewLocalCollection allows sqladapter create a local db.Collection.

--- a/sqlite/Makefile
+++ b/sqlite/Makefile
@@ -21,4 +21,5 @@ reset-db: require-client
 	rm -f $(DB_NAME)
 
 test: reset-db generate
-	go test -tags generated -v -race
+	#go test -tags generated -v -race # race: limit on 8192 simultaneously alive goroutines is exceeded, dying
+	go test -tags generated -v

--- a/sqlite/connection.go
+++ b/sqlite/connection.go
@@ -58,6 +58,10 @@ func (c ConnectionURL) String() (s string) {
 		c.Options = map[string]string{}
 	}
 
+	if _, ok := c.Options["_busy_timeout"]; !ok {
+		c.Options["_busy_timeout"] = "10000"
+	}
+
 	// Converting options into URL values.
 	for k, v := range c.Options {
 		vv.Set(k, v)

--- a/sqlite/connection_test.go
+++ b/sqlite/connection_test.go
@@ -40,7 +40,7 @@ func TestConnectionURL(t *testing.T) {
 
 	absoluteName, _ := filepath.Abs(c.Database)
 
-	if c.String() != "file://"+absoluteName {
+	if c.String() != "file://"+absoluteName+"?_busy_timeout=10000" {
 		t.Fatal(`Test failed, got:`, c.String())
 	}
 
@@ -50,14 +50,14 @@ func TestConnectionURL(t *testing.T) {
 		"mode":  "ro",
 	}
 
-	if c.String() != "file://"+absoluteName+"?cache=foobar&mode=ro" {
+	if c.String() != "file://"+absoluteName+"?_busy_timeout=10000&cache=foobar&mode=ro" {
 		t.Fatal(`Test failed, got:`, c.String())
 	}
 
 	// Setting another database.
 	c.Database = "/another/database"
 
-	if c.String() != `file:///another/database?cache=foobar&mode=ro` {
+	if c.String() != `file:///another/database?_busy_timeout=10000&cache=foobar&mode=ro` {
 		t.Fatal(`Test failed, got:`, c.String())
 	}
 
@@ -82,7 +82,7 @@ func TestParseConnectionURL(t *testing.T) {
 		t.Fatal("If not defined, cache should be shared by default.")
 	}
 
-	s = "file:///path/to/my/database.db?mode=ro&cache=foobar"
+	s = "file:///path/to/my/database.db?_busy_timeout=10000&mode=ro&cache=foobar"
 
 	if u, err = ParseURL(s); err != nil {
 		t.Fatal(err)

--- a/sqlite/tx.go
+++ b/sqlite/tx.go
@@ -22,8 +22,8 @@
 package sqlite
 
 import (
-	"upper.io/db.v2"
 	"upper.io/db.v2/internal/sqladapter"
+	"upper.io/db.v2/lib/sqlbuilder"
 )
 
 type tx struct {
@@ -31,19 +31,5 @@ type tx struct {
 }
 
 var (
-	_ = db.Tx(&tx{})
+	_ = sqlbuilder.Tx(&tx{})
 )
-
-func (t *tx) Commit() error {
-	if sess := t.Session(); sess != nil {
-		defer sess.Close()
-	}
-	return t.DatabaseTx.Commit()
-}
-
-func (t *tx) Rollback() error {
-	if sess := t.Session(); sess != nil {
-		defer sess.Close()
-	}
-	return t.DatabaseTx.Rollback()
-}


### PR DESCRIPTION
Also provides more tests that aggressively create and eject prepared statements and methods for setting connection limits (per session).