### PR TITLE
Immutable statements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,9 @@ DB_HOST ?= 127.0.0.1
 export DB_HOST
 
 test:
-	go test -v -benchtime=500ms -bench=. ./lib/... & \
-	go test -v -benchtime=500ms -bench=. ./internal/... & \
-	wait && \
+	go test -v -benchtime=500ms -bench=. ./lib/... && \
+	go test -v -benchtime=500ms -bench=. ./internal/... && \
 	for ADAPTER in postgresql mysql sqlite ql mongo; do \
-		$(MAKE) -C $$ADAPTER test & \
+		$(MAKE) -C $$ADAPTER test; \
 	done && \
-	wait && \
 	go test -v

--- a/README.md
+++ b/README.md
@@ -86,6 +86,39 @@ go run _examples/booktown-books/main.go
 2016/08/10 08:42:48 "Practical PostgreSQL" (ID: 41472)
 ```
 
+## Changeog
+
+Dec 15th, 2016: Before `2.0.0-rc8`, upper-db produced queries that mutated
+themselves:
+
+```
+q := sess.SelectFrom("users")
+
+q.Where(...) // This method modified q's internal state.
+```
+
+Starting on `2.0.0-rc8` this is no longer valid, if you want to use values to
+represent queries you'll have to reassign them, like this:
+
+```
+q := sess.SelectFrom("users")
+
+q = q.Where(...)
+
+q.And(...) // Nothing happens, the Where() method does not affect q.
+```
+
+This applies to all query builder methods, `db.Result`, `db.And` and `db.Or`.
+
+If you want to check your code for statatements that might rely on the old
+behaviour and could cause you trouble use `dbcheck`:
+
+```
+go get -u github.com/upper/cmd/dbcheck
+
+dbcheck github.com/my/package/...
+```
+
 ## License
 
 This project is licensed under the terms of the **MIT License**.

--- a/db.go
+++ b/db.go
@@ -266,11 +266,13 @@ type compound struct {
 }
 
 func newCompound(conds ...Compound) *compound {
-	return &compound{
-		fn: func() []Compound {
+	c := &compound{}
+	if len(conds) > 0 {
+		c.fn = func() []Compound {
 			return conds
-		},
+		}
 	}
+	return c
 }
 
 func defaultJoin(in ...Compound) []Compound {
@@ -307,7 +309,7 @@ func (c *compound) frame(a []Compound) *compound {
 }
 
 func compoundFastForward(curr *compound) []Compound {
-	if curr == nil {
+	if curr == nil || curr.fn == nil {
 		return []Compound{}
 	}
 	return append(compoundFastForward(curr.prev), curr.fn()...)

--- a/internal/immutable/immutable.go
+++ b/internal/immutable/immutable.go
@@ -1,0 +1,22 @@
+package immutable
+
+// Immutable represents immutable chains
+type Immutable interface {
+	Prev() Immutable
+	Fn(interface{}) error
+	Base() interface{}
+}
+
+// FastForward applies all Fn methods in order on the given new Base.
+func FastForward(curr Immutable) (interface{}, error) {
+	prev := curr.Prev()
+	if prev == nil {
+		return curr.Base(), nil
+	}
+	in, err := FastForward(prev)
+	if err != nil {
+		return nil, err
+	}
+	err = curr.Fn(in)
+	return in, err
+}

--- a/internal/sqladapter/exql/column_value.go
+++ b/internal/sqladapter/exql/column_value.go
@@ -35,6 +35,9 @@ func (c *ColumnValue) Compile(layout *Template) (compiled string) {
 		c.Operator,
 		c.Value.Compile(layout),
 	}
+	if c.Operator == "" {
+		data.Operator = layout.DefaultOperator
+	}
 
 	compiled = mustParse(layout.ColumnValue, data)
 

--- a/internal/sqladapter/exql/column_value_test.go
+++ b/internal/sqladapter/exql/column_value_test.go
@@ -54,6 +54,15 @@ func TestColumnValue(t *testing.T) {
 	if s != e {
 		t.Fatalf("Got: %s, Expecting: %s", s, e)
 	}
+
+	cv = &ColumnValue{Column: ColumnWithName("date"), Value: NewValue(RawValue("NOW()"))}
+
+	s = cv.Compile(defaultTemplate)
+	e = `"date" = NOW()`
+
+	if s != e {
+		t.Fatalf("Got: %s, Expecting: %s", s, e)
+	}
 }
 
 func TestColumnValues(t *testing.T) {

--- a/internal/sqladapter/result.go
+++ b/internal/sqladapter/result.go
@@ -212,15 +212,11 @@ func (r *Result) Count() (uint64, error) {
 }
 
 func (r *Result) buildSelect() sqlbuilder.Selector {
-	q := r.b.Select(r.fields...)
-
-	q.From(r.table)
-	q.Where(filter(r.conds)...)
-	q.Limit(r.limit)
-	q.Offset(r.offset)
-
-	q.GroupBy(r.groupBy...)
-	q.OrderBy(r.orderBy...)
-
-	return q
+	return r.b.Select(r.fields...).
+		From(r.table).
+		Where(filter(r.conds)...).
+		Limit(r.limit).
+		Offset(r.offset).
+		GroupBy(r.groupBy...).
+		OrderBy(r.orderBy...)
 }

--- a/lib/sqlbuilder/batch.go
+++ b/lib/sqlbuilder/batch.go
@@ -28,11 +28,12 @@ func (b *BatchInserter) Values(values ...interface{}) *BatchInserter {
 }
 
 func (b *BatchInserter) nextQuery() *inserter {
-	clone := b.inserter.clone()
+	ins := &inserter{}
+	*ins = *b.inserter
 	i := 0
 	for values := range b.values {
 		i++
-		clone = clone.Values(values...).(*inserter)
+		ins = ins.Values(values...).(*inserter)
 		if i == b.size {
 			break
 		}
@@ -40,7 +41,7 @@ func (b *BatchInserter) nextQuery() *inserter {
 	if i == 0 {
 		return nil
 	}
-	return clone
+	return ins
 }
 
 // NextResult is useful when using PostgreSQL and Returning(), it dumps the

--- a/lib/sqlbuilder/batch.go
+++ b/lib/sqlbuilder/batch.go
@@ -32,7 +32,7 @@ func (b *BatchInserter) nextQuery() *inserter {
 	i := 0
 	for values := range b.values {
 		i++
-		clone.Values(values...)
+		clone = clone.Values(values...).(*inserter)
 		if i == b.size {
 			break
 		}

--- a/lib/sqlbuilder/builder.go
+++ b/lib/sqlbuilder/builder.go
@@ -26,6 +26,10 @@ var defaultMapOptions = MapOptions{
 	IncludeNil:    false,
 }
 
+type hasStringer interface {
+	Stringer() *stringer
+}
+
 type hasIsZero interface {
 	IsZero() bool
 }
@@ -312,7 +316,7 @@ func extractArguments(fragments []interface{}) []interface{} {
 	return args
 }
 
-func columnFragments(template *templateWithUtils, columns []interface{}) ([]exql.Fragment, []interface{}, error) {
+func columnFragments(columns []interface{}) ([]exql.Fragment, []interface{}, error) {
 	l := len(columns)
 	f := make([]exql.Fragment, l)
 	args := []interface{}{}
@@ -320,7 +324,7 @@ func columnFragments(template *templateWithUtils, columns []interface{}) ([]exql
 	for i := 0; i < l; i++ {
 		switch v := columns[i].(type) {
 		case *selector:
-			expanded, rawArgs := expandPlaceholders(v.statement().Compile(v.stringer.t), v.Arguments()...)
+			expanded, rawArgs := expandPlaceholders(v.Compile(), v.Arguments()...)
 			f[i] = exql.RawValue(expanded)
 			args = append(args, rawArgs...)
 		case db.Function:

--- a/lib/sqlbuilder/builder.go
+++ b/lib/sqlbuilder/builder.go
@@ -164,11 +164,10 @@ func (b *sqlBuilder) Select(columns ...interface{}) Selector {
 func (b *sqlBuilder) InsertInto(table string) Inserter {
 	qi := &inserter{
 		builder: b,
-		table:   table,
 	}
 
 	qi.stringer = &stringer{qi, b.t.Template}
-	return qi
+	return qi.Into(table)
 }
 
 func (b *sqlBuilder) DeleteFrom(table string) Deleter {

--- a/lib/sqlbuilder/builder.go
+++ b/lib/sqlbuilder/builder.go
@@ -182,13 +182,11 @@ func (b *sqlBuilder) DeleteFrom(table string) Deleter {
 
 func (b *sqlBuilder) Update(table string) Updater {
 	qu := &updater{
-		builder:      b,
-		table:        table,
-		columnValues: &exql.ColumnValues{},
+		builder: b,
 	}
 
 	qu.stringer = &stringer{qu, b.t.Template}
-	return qu
+	return qu.setTable(table)
 }
 
 // Map receives a pointer to map or struct and maps it to columns and values.

--- a/lib/sqlbuilder/builder.go
+++ b/lib/sqlbuilder/builder.go
@@ -173,11 +173,10 @@ func (b *sqlBuilder) InsertInto(table string) Inserter {
 func (b *sqlBuilder) DeleteFrom(table string) Deleter {
 	qd := &deleter{
 		builder: b,
-		table:   table,
 	}
 
 	qd.stringer = &stringer{qd, b.t.Template}
-	return qd
+	return qd.setTable(table)
 }
 
 func (b *sqlBuilder) Update(table string) Updater {

--- a/lib/sqlbuilder/builder_test.go
+++ b/lib/sqlbuilder/builder_test.go
@@ -628,7 +628,7 @@ func TestSelect(t *testing.T) {
 			Where(db.Cond{"hub_id": 3})
 
 		// Don't reassign
-		sq.And(db.Cond{"role": []int{1, 2}})
+		_ = sq.And(db.Cond{"role": []int{1, 2}})
 
 		assert.Equal(
 			`SELECT "user_id" FROM "user_access" WHERE ("hub_id" = $1)`,

--- a/lib/sqlbuilder/builder_test.go
+++ b/lib/sqlbuilder/builder_test.go
@@ -627,7 +627,21 @@ func TestSelect(t *testing.T) {
 			From("user_access").
 			Where(db.Cond{"hub_id": 3})
 
+		// Don't reassign
 		sq.And(db.Cond{"role": []int{1, 2}})
+
+		assert.Equal(
+			`SELECT "user_id" FROM "user_access" WHERE ("hub_id" = $1)`,
+			sq.String(),
+		)
+
+		assert.Equal(
+			[]interface{}{3},
+			sq.Arguments(),
+		)
+
+		// Reassign
+		sq = sq.And(db.Cond{"role": []int{1, 2}})
 
 		assert.Equal(
 			`SELECT "user_id" FROM "user_access" WHERE ("hub_id" = $1 AND "role" IN ($2, $3))`,
@@ -652,7 +666,7 @@ func TestSelect(t *testing.T) {
 			Where(cond)
 
 		search := "word"
-		sel.And(db.Or(
+		sel = sel.And(db.Or(
 			db.Raw("COALESCE(NULLIF(ml.name,''), a.name) ILIKE ?", fmt.Sprintf("%%%s%%", search)),
 			db.Cond{"a.email ILIKE": fmt.Sprintf("%%%s%%", search)},
 		))
@@ -666,7 +680,6 @@ func TestSelect(t *testing.T) {
 			[]interface{}{3, 1, 2, 4, 5, 6, `%word%`, `%word%`},
 			sel.Arguments(),
 		)
-
 	}
 }
 

--- a/lib/sqlbuilder/builder_test.go
+++ b/lib/sqlbuilder/builder_test.go
@@ -657,7 +657,7 @@ func TestSelect(t *testing.T) {
 			db.Raw("a.id IN ?", sq),
 		)
 
-		cond.Or(db.Cond{"ml.mailing_list_id": []int{4, 5, 6}})
+		cond = cond.Or(db.Cond{"ml.mailing_list_id": []int{4, 5, 6}})
 
 		sel := b.
 			Select(db.Raw("DISTINCT ON(a.id) a.id"), db.Raw("COALESCE(NULLIF(ml.name,''), a.name) as name"), "a.email").

--- a/lib/sqlbuilder/convert.go
+++ b/lib/sqlbuilder/convert.go
@@ -45,7 +45,7 @@ func expandPlaceholders(in string, args ...interface{}) (string, []interface{}) 
 						case db.RawValue:
 							k, values = t.Raw(), nil
 						case *selector:
-							k, values = `(`+t.statement().Compile(t.stringer.t)+`)`, t.Arguments()
+							k, values = `(`+t.Compile()+`)`, t.Arguments()
 						}
 					} else if len(values) == 0 {
 						k = `NULL`
@@ -368,4 +368,218 @@ func (tu *templateWithUtils) ToColumnsValuesAndArguments(columnNames []string, c
 	}
 
 	return columns, values, arguments, nil
+}
+
+// ToWhereWithArguments converts the given parameters into a exql.Where
+// value.
+func toWhereWithArguments(term interface{}) (where exql.Where, args []interface{}) {
+	args = []interface{}{}
+
+	switch t := term.(type) {
+	case []interface{}:
+		if len(t) > 0 {
+			if s, ok := t[0].(string); ok {
+				if strings.ContainsAny(s, "?") || len(t) == 1 {
+					s, args = expandPlaceholders(s, t[1:]...)
+					where.Conditions = []exql.Fragment{exql.RawValue(s)}
+				} else {
+					var val interface{}
+					key := s
+					if len(t) > 2 {
+						val = t[1:]
+					} else {
+						val = t[1]
+					}
+					cv, v := toColumnValues(db.NewConstraint(key, val))
+					args = append(args, v...)
+					for i := range cv.ColumnValues {
+						where.Conditions = append(where.Conditions, cv.ColumnValues[i])
+					}
+				}
+				return
+			}
+		}
+		for i := range t {
+			w, v := toWhereWithArguments(t[i])
+			if len(w.Conditions) == 0 {
+				continue
+			}
+			args = append(args, v...)
+			where.Conditions = append(where.Conditions, w.Conditions...)
+		}
+		return
+	case db.RawValue:
+		r, v := expandPlaceholders(t.Raw(), t.Arguments()...)
+		where.Conditions = []exql.Fragment{exql.RawValue(r)}
+		args = append(args, v...)
+		return
+	case db.Constraints:
+		for _, c := range t.Constraints() {
+			w, v := toWhereWithArguments(c)
+			if len(w.Conditions) == 0 {
+				continue
+			}
+			args = append(args, v...)
+			where.Conditions = append(where.Conditions, w.Conditions...)
+		}
+		return
+	case db.Compound:
+		var cond exql.Where
+
+		for _, c := range t.Sentences() {
+			w, v := toWhereWithArguments(c)
+			if len(w.Conditions) == 0 {
+				continue
+			}
+			args = append(args, v...)
+			cond.Conditions = append(cond.Conditions, w.Conditions...)
+		}
+
+		if len(cond.Conditions) > 0 {
+			var frag exql.Fragment
+			switch t.Operator() {
+			case db.OperatorNone, db.OperatorAnd:
+				q := exql.And(cond)
+				frag = &q
+			case db.OperatorOr:
+				q := exql.Or(cond)
+				frag = &q
+			default:
+				panic(fmt.Sprintf("Unknown type %T", t))
+			}
+			where.Conditions = append(where.Conditions, frag)
+		}
+
+		return
+	case db.Constraint:
+		cv, v := toColumnValues(t)
+		args = append(args, v...)
+		where.Conditions = append(where.Conditions, cv.ColumnValues...)
+		return where, args
+	}
+
+	panic(fmt.Sprintf("Unknown condition type %T", term))
+}
+
+func toColumnValues(term interface{}) (cv exql.ColumnValues, args []interface{}) {
+	args = []interface{}{}
+
+	switch t := term.(type) {
+	case []interface{}:
+		l := len(t)
+		for i := 0; i < l; i++ {
+			column := t[i].(string)
+
+			if !strings.ContainsAny(column, "=") {
+				column = fmt.Sprintf("%s = ?", column)
+			}
+
+			chunks := strings.SplitN(column, "=", 2)
+
+			column = chunks[0]
+			format := strings.TrimSpace(chunks[1])
+
+			columnValue := exql.ColumnValue{
+				Column:   exql.ColumnWithName(column),
+				Operator: "=",
+				Value:    exql.RawValue(format),
+			}
+
+			ps := strings.Count(format, "?")
+			if i+ps < l {
+				for j := 0; j < ps; j++ {
+					args = append(args, t[i+j+1])
+				}
+				i = i + ps
+			} else {
+				panic(fmt.Sprintf("Format string %q has more placeholders than given arguments.", format))
+			}
+
+			cv.ColumnValues = append(cv.ColumnValues, &columnValue)
+		}
+		return cv, args
+	case db.Constraint:
+		columnValue := exql.ColumnValue{}
+
+		// Guessing operator from input, or using a default one.
+		if column, ok := t.Key().(string); ok {
+			chunks := strings.SplitN(strings.TrimSpace(column), ` `, 2)
+			columnValue.Column = exql.ColumnWithName(chunks[0])
+			if len(chunks) > 1 {
+				columnValue.Operator = chunks[1]
+			}
+		} else {
+			if rawValue, ok := t.Key().(db.RawValue); ok {
+				columnValue.Column = exql.RawValue(rawValue.Raw())
+				args = append(args, rawValue.Arguments()...)
+			} else {
+				columnValue.Column = exql.RawValue(fmt.Sprintf("%v", t.Key()))
+			}
+		}
+
+		switch value := t.Value().(type) {
+		case db.Function:
+			fnName, fnArgs := value.Name(), value.Arguments()
+			if len(fnArgs) == 0 {
+				// A function with no arguments.
+				fnName = fnName + "()"
+			} else {
+				// A function with one or more arguments.
+				fnName = fnName + "(?" + strings.Repeat("?, ", len(fnArgs)-1) + ")"
+			}
+			expanded, fnArgs := expandPlaceholders(fnName, fnArgs...)
+			columnValue.Value = exql.RawValue(expanded)
+			args = append(args, fnArgs...)
+		case db.RawValue:
+			expanded, rawArgs := expandPlaceholders(value.Raw(), value.Arguments()...)
+			columnValue.Value = exql.RawValue(expanded)
+			args = append(args, rawArgs...)
+		default:
+			v, isSlice := toInterfaceArguments(value)
+
+			if isSlice {
+				if columnValue.Operator == "" {
+					columnValue.Operator = sqlInOperator
+				}
+				if len(v) > 0 {
+					// Array value given.
+					columnValue.Value = exql.RawValue(fmt.Sprintf(`(?%s)`, strings.Repeat(`, ?`, len(v)-1)))
+				} else {
+					// Single value given.
+					columnValue.Value = exql.RawValue(`(NULL)`)
+				}
+				args = append(args, v...)
+			} else {
+				if v == nil {
+					// Nil value given.
+					columnValue.Value = sqlNull
+					if columnValue.Operator == "" {
+						columnValue.Operator = sqlIsOperator
+					}
+				} else {
+					columnValue.Value = sqlPlaceholder
+					args = append(args, v...)
+				}
+			}
+
+		}
+
+		// Using guessed operator if no operator was given.
+		if columnValue.Operator == "" {
+			columnValue.Operator = sqlDefaultOperator
+		}
+
+		cv.ColumnValues = append(cv.ColumnValues, &columnValue)
+
+		return cv, args
+	case db.Constraints:
+		for _, c := range t.Constraints() {
+			p, q := toColumnValues(c)
+			cv.ColumnValues = append(cv.ColumnValues, p.ColumnValues...)
+			args = append(args, q...)
+		}
+		return cv, args
+	}
+
+	panic(fmt.Sprintf("Unknown term type %T.", term))
 }

--- a/lib/sqlbuilder/convert.go
+++ b/lib/sqlbuilder/convert.go
@@ -67,97 +67,6 @@ func expandPlaceholders(in string, args ...interface{}) (string, []interface{}) 
 	return in, argx
 }
 
-// ToWhereWithArguments converts the given parameters into a exql.Where
-// value.
-func (tu *templateWithUtils) ToWhereWithArguments(term interface{}) (where exql.Where, args []interface{}) {
-	args = []interface{}{}
-
-	switch t := term.(type) {
-	case []interface{}:
-		if len(t) > 0 {
-			if s, ok := t[0].(string); ok {
-				if strings.ContainsAny(s, "?") || len(t) == 1 {
-					s, args = expandPlaceholders(s, t[1:]...)
-					where.Conditions = []exql.Fragment{exql.RawValue(s)}
-				} else {
-					var val interface{}
-					key := s
-					if len(t) > 2 {
-						val = t[1:]
-					} else {
-						val = t[1]
-					}
-					cv, v := tu.ToColumnValues(db.NewConstraint(key, val))
-					args = append(args, v...)
-					for i := range cv.ColumnValues {
-						where.Conditions = append(where.Conditions, cv.ColumnValues[i])
-					}
-				}
-				return
-			}
-		}
-		for i := range t {
-			w, v := tu.ToWhereWithArguments(t[i])
-			if len(w.Conditions) == 0 {
-				continue
-			}
-			args = append(args, v...)
-			where.Conditions = append(where.Conditions, w.Conditions...)
-		}
-		return
-	case db.RawValue:
-		r, v := expandPlaceholders(t.Raw(), t.Arguments()...)
-		where.Conditions = []exql.Fragment{exql.RawValue(r)}
-		args = append(args, v...)
-		return
-	case db.Constraints:
-		for _, c := range t.Constraints() {
-			w, v := tu.ToWhereWithArguments(c)
-			if len(w.Conditions) == 0 {
-				continue
-			}
-			args = append(args, v...)
-			where.Conditions = append(where.Conditions, w.Conditions...)
-		}
-		return
-	case db.Compound:
-		var cond exql.Where
-
-		for _, c := range t.Sentences() {
-			w, v := tu.ToWhereWithArguments(c)
-			if len(w.Conditions) == 0 {
-				continue
-			}
-			args = append(args, v...)
-			cond.Conditions = append(cond.Conditions, w.Conditions...)
-		}
-
-		if len(cond.Conditions) > 0 {
-			var frag exql.Fragment
-			switch t.Operator() {
-			case db.OperatorNone, db.OperatorAnd:
-				q := exql.And(cond)
-				frag = &q
-			case db.OperatorOr:
-				q := exql.Or(cond)
-				frag = &q
-			default:
-				panic(fmt.Sprintf("Unknown type %T", t))
-			}
-			where.Conditions = append(where.Conditions, frag)
-		}
-
-		return
-	case db.Constraint:
-		cv, v := tu.ToColumnValues(t)
-		args = append(args, v...)
-		where.Conditions = append(where.Conditions, cv.ColumnValues...)
-		return where, args
-	}
-
-	panic(fmt.Sprintf("Unknown condition type %T", term))
-}
-
 func (tu *templateWithUtils) PlaceholderValue(in interface{}) (exql.Fragment, []interface{}) {
 	switch t := in.(type) {
 	case db.RawValue:
@@ -207,137 +116,9 @@ func toInterfaceArguments(value interface{}) (args []interface{}, isSlice bool) 
 	return []interface{}{value}, false
 }
 
-// ToColumnValues converts the given conditions into a exql.ColumnValues struct.
-func (tu *templateWithUtils) ToColumnValues(term interface{}) (cv exql.ColumnValues, args []interface{}) {
-	args = []interface{}{}
-
-	switch t := term.(type) {
-	case []interface{}:
-		l := len(t)
-		for i := 0; i < l; i++ {
-			column := t[i].(string)
-
-			if !strings.ContainsAny(column, "=") {
-				column = fmt.Sprintf("%s = ?", column)
-			}
-
-			chunks := strings.SplitN(column, "=", 2)
-
-			column = chunks[0]
-			format := strings.TrimSpace(chunks[1])
-
-			columnValue := exql.ColumnValue{
-				Column:   exql.ColumnWithName(column),
-				Operator: "=",
-				Value:    exql.RawValue(format),
-			}
-
-			ps := strings.Count(format, "?")
-			if i+ps < l {
-				for j := 0; j < ps; j++ {
-					args = append(args, t[i+j+1])
-				}
-				i = i + ps
-			} else {
-				panic(fmt.Sprintf("Format string %q has more placeholders than given arguments.", format))
-			}
-
-			cv.ColumnValues = append(cv.ColumnValues, &columnValue)
-		}
-		return cv, args
-	case db.Constraint:
-		columnValue := exql.ColumnValue{}
-
-		// Guessing operator from input, or using a default one.
-		if column, ok := t.Key().(string); ok {
-			chunks := strings.SplitN(strings.TrimSpace(column), ` `, 2)
-			columnValue.Column = exql.ColumnWithName(chunks[0])
-			if len(chunks) > 1 {
-				columnValue.Operator = chunks[1]
-			}
-		} else {
-			if rawValue, ok := t.Key().(db.RawValue); ok {
-				columnValue.Column = exql.RawValue(rawValue.Raw())
-				args = append(args, rawValue.Arguments()...)
-			} else {
-				columnValue.Column = exql.RawValue(fmt.Sprintf("%v", t.Key()))
-			}
-		}
-
-		switch value := t.Value().(type) {
-		case db.Function:
-			fnName, fnArgs := value.Name(), value.Arguments()
-			if len(fnArgs) == 0 {
-				// A function with no arguments.
-				fnName = fnName + "()"
-			} else {
-				// A function with one or more arguments.
-				fnName = fnName + "(?" + strings.Repeat("?, ", len(fnArgs)-1) + ")"
-			}
-			expanded, fnArgs := expandPlaceholders(fnName, fnArgs...)
-			columnValue.Value = exql.RawValue(expanded)
-			args = append(args, fnArgs...)
-		case db.RawValue:
-			expanded, rawArgs := expandPlaceholders(value.Raw(), value.Arguments()...)
-			columnValue.Value = exql.RawValue(expanded)
-			args = append(args, rawArgs...)
-		default:
-			v, isSlice := toInterfaceArguments(value)
-
-			if isSlice {
-				if columnValue.Operator == "" {
-					columnValue.Operator = sqlInOperator
-				}
-				if len(v) > 0 {
-					// Array value given.
-					columnValue.Value = exql.RawValue(fmt.Sprintf(`(?%s)`, strings.Repeat(`, ?`, len(v)-1)))
-				} else {
-					// Single value given.
-					columnValue.Value = exql.RawValue(`(NULL)`)
-				}
-				args = append(args, v...)
-			} else {
-				if v == nil {
-					// Nil value given.
-					columnValue.Value = sqlNull
-					if columnValue.Operator == "" {
-						columnValue.Operator = sqlIsOperator
-					}
-				} else {
-					columnValue.Value = sqlPlaceholder
-					args = append(args, v...)
-				}
-			}
-
-		}
-
-		// Using guessed operator if no operator was given.
-		if columnValue.Operator == "" {
-			if tu.DefaultOperator != "" {
-				columnValue.Operator = tu.DefaultOperator
-			} else {
-				columnValue.Operator = sqlDefaultOperator
-			}
-		}
-
-		cv.ColumnValues = append(cv.ColumnValues, &columnValue)
-
-		return cv, args
-	case db.Constraints:
-		for _, c := range t.Constraints() {
-			p, q := tu.ToColumnValues(c)
-			cv.ColumnValues = append(cv.ColumnValues, p.ColumnValues...)
-			args = append(args, q...)
-		}
-		return cv, args
-	}
-
-	panic(fmt.Sprintf("Unknown term type %T.", term))
-}
-
-// ToColumnsValuesAndArguments maps the given columnNames and columnValues into
+// toColumnsValuesAndArguments maps the given columnNames and columnValues into
 // expr's Columns and Values, it also extracts and returns query arguments.
-func (tu *templateWithUtils) ToColumnsValuesAndArguments(columnNames []string, columnValues []interface{}) (*exql.Columns, *exql.Values, []interface{}, error) {
+func toColumnsValuesAndArguments(columnNames []string, columnValues []interface{}) (*exql.Columns, *exql.Values, []interface{}, error) {
 	var arguments []interface{}
 
 	columns := new(exql.Columns)
@@ -370,7 +151,7 @@ func (tu *templateWithUtils) ToColumnsValuesAndArguments(columnNames []string, c
 	return columns, values, arguments, nil
 }
 
-// ToWhereWithArguments converts the given parameters into a exql.Where
+// toWhereWithArguments converts the given parameters into a exql.Where
 // value.
 func toWhereWithArguments(term interface{}) (where exql.Where, args []interface{}) {
 	args = []interface{}{}

--- a/lib/sqlbuilder/delete.go
+++ b/lib/sqlbuilder/delete.go
@@ -2,52 +2,147 @@ package sqlbuilder
 
 import (
 	"database/sql"
+	"strings"
 
 	"upper.io/db.v2/internal/sqladapter/exql"
 )
 
-type deleter struct {
-	*stringer
-	builder   *sqlBuilder
+type deleterQuery struct {
 	table     string
 	limit     int
 	where     *exql.Where
 	arguments []interface{}
 }
 
-func (qd *deleter) Where(terms ...interface{}) Deleter {
-	where, arguments := toWhereWithArguments(terms)
-	qd.where = &where
-	qd.arguments = append(qd.arguments, arguments...)
-	return qd
-}
-
-func (qd *deleter) Limit(limit int) Deleter {
-	qd.limit = limit
-	return qd
-}
-
-func (qd *deleter) Arguments() []interface{} {
-	return qd.arguments
-}
-
-func (qd *deleter) Exec() (sql.Result, error) {
-	return qd.builder.sess.StatementExec(qd.statement(), qd.arguments...)
-}
-
-func (qd *deleter) statement() *exql.Statement {
+func (dq *deleterQuery) statement() *exql.Statement {
 	stmt := &exql.Statement{
 		Type:  exql.Delete,
-		Table: exql.TableWithName(qd.table),
+		Table: exql.TableWithName(dq.table),
 	}
 
-	if qd.Where != nil {
-		stmt.Where = qd.where
+	if dq.where != nil {
+		stmt.Where = dq.where
 	}
 
-	if qd.limit != 0 {
-		stmt.Limit = exql.Limit(qd.limit)
+	if dq.limit != 0 {
+		stmt.Limit = exql.Limit(dq.limit)
 	}
 
 	return stmt
+}
+
+type deleter struct {
+	*stringer
+	builder *sqlBuilder
+
+	fn   func(*deleterQuery) error
+	prev *deleter
+}
+
+func (del *deleter) Builder() *sqlBuilder {
+	p := &del
+	for {
+		if (*p).builder != nil {
+			return (*p).builder
+		}
+		if (*p).prev == nil {
+			return nil
+		}
+		p = &(*p).prev
+	}
+}
+
+func (del *deleter) Stringer() *stringer {
+	p := &del
+	for {
+		if (*p).stringer != nil {
+			return (*p).stringer
+		}
+		if (*p).prev == nil {
+			return nil
+		}
+		p = &(*p).prev
+	}
+}
+
+func (del *deleter) String() string {
+	query, err := del.build()
+	if err != nil {
+		return ""
+	}
+	q := del.Stringer().compileAndReplacePlaceholders(query.statement())
+	q = reInvisibleChars.ReplaceAllString(q, ` `)
+	return strings.TrimSpace(q)
+}
+
+func (del *deleter) setTable(table string) *deleter {
+	return del.frame(func(uq *deleterQuery) error {
+		uq.table = table
+		return nil
+	})
+}
+
+func (del *deleter) frame(fn func(*deleterQuery) error) *deleter {
+	return &deleter{prev: del, fn: fn}
+}
+
+func (del *deleter) Where(terms ...interface{}) Deleter {
+	return del.frame(func(dq *deleterQuery) error {
+		where, arguments := toWhereWithArguments(terms)
+		dq.where = &where
+		dq.arguments = append(dq.arguments, arguments...)
+		return nil
+	})
+}
+
+func (del *deleter) Limit(limit int) Deleter {
+	return del.frame(func(dq *deleterQuery) error {
+		dq.limit = limit
+		return nil
+	})
+}
+
+func (del *deleter) Arguments() []interface{} {
+	dq, err := del.build()
+	if err != nil {
+		return nil
+	}
+	return dq.arguments
+}
+
+func (del *deleter) Exec() (sql.Result, error) {
+	dq, err := del.build()
+	if err != nil {
+		return nil, err
+	}
+	return del.builder.sess.StatementExec(dq.statement(), dq.arguments...)
+}
+
+func (del *deleter) statement() *exql.Statement {
+	iq, _ := del.build()
+	return iq.statement()
+}
+
+func (del *deleter) build() (*deleterQuery, error) {
+	iq, err := deleterFastForward(&deleterQuery{}, del)
+	if err != nil {
+		return nil, err
+	}
+	return iq, nil
+}
+
+func (del *deleter) Compile() string {
+	return del.statement().Compile(del.Stringer().t)
+}
+
+func deleterFastForward(in *deleterQuery, curr *deleter) (*deleterQuery, error) {
+	if curr == nil || curr.fn == nil {
+		return in, nil
+	}
+	in, err := deleterFastForward(in, curr.prev)
+	if err != nil {
+		return nil, err
+	}
+	err = curr.fn(in)
+	return in, err
 }

--- a/lib/sqlbuilder/delete.go
+++ b/lib/sqlbuilder/delete.go
@@ -115,7 +115,7 @@ func (del *deleter) Exec() (sql.Result, error) {
 	if err != nil {
 		return nil, err
 	}
-	return del.builder.sess.StatementExec(dq.statement(), dq.arguments...)
+	return del.Builder().sess.StatementExec(dq.statement(), dq.arguments...)
 }
 
 func (del *deleter) statement() *exql.Statement {

--- a/lib/sqlbuilder/delete.go
+++ b/lib/sqlbuilder/delete.go
@@ -16,7 +16,7 @@ type deleter struct {
 }
 
 func (qd *deleter) Where(terms ...interface{}) Deleter {
-	where, arguments := qd.builder.t.ToWhereWithArguments(terms)
+	where, arguments := toWhereWithArguments(terms)
 	qd.where = &where
 	qd.arguments = append(qd.arguments, arguments...)
 	return qd

--- a/lib/sqlbuilder/insert.go
+++ b/lib/sqlbuilder/insert.go
@@ -55,6 +55,19 @@ type inserter struct {
 	prev *inserter
 }
 
+func (ins *inserter) Builder() *sqlBuilder {
+	p := &ins
+	for {
+		if (*p).builder != nil {
+			return (*p).builder
+		}
+		if (*p).prev == nil {
+			return nil
+		}
+		p = &(*p).prev
+	}
+}
+
 func (ins *inserter) Stringer() *stringer {
 	p := &ins
 	for {
@@ -79,7 +92,7 @@ func (ins *inserter) String() string {
 }
 
 func (ins *inserter) frame(fn func(*inserterQuery) error) *inserter {
-	return &inserter{prev: ins, fn: fn, builder: ins.builder}
+	return &inserter{prev: ins, fn: fn}
 }
 
 func (ins *inserter) clone() *inserter {
@@ -112,7 +125,7 @@ func (ins *inserter) Exec() (sql.Result, error) {
 	if err != nil {
 		return nil, err
 	}
-	return ins.builder.sess.StatementExec(iq.statement(), iq.arguments...)
+	return ins.Builder().sess.StatementExec(iq.statement(), iq.arguments...)
 }
 
 func (ins *inserter) Query() (*sql.Rows, error) {
@@ -120,7 +133,7 @@ func (ins *inserter) Query() (*sql.Rows, error) {
 	if err != nil {
 		return nil, err
 	}
-	return ins.builder.sess.StatementQuery(iq.statement(), iq.arguments...)
+	return ins.Builder().sess.StatementQuery(iq.statement(), iq.arguments...)
 }
 
 func (ins *inserter) QueryRow() (*sql.Row, error) {
@@ -128,7 +141,7 @@ func (ins *inserter) QueryRow() (*sql.Row, error) {
 	if err != nil {
 		return nil, err
 	}
-	return ins.builder.sess.StatementQueryRow(iq.statement(), iq.arguments...)
+	return ins.Builder().sess.StatementQueryRow(iq.statement(), iq.arguments...)
 }
 
 func (ins *inserter) Iterator() Iterator {

--- a/lib/sqlbuilder/insert.go
+++ b/lib/sqlbuilder/insert.go
@@ -79,7 +79,7 @@ func (ins *inserter) String() string {
 }
 
 func (ins *inserter) frame(fn func(*inserterQuery) error) *inserter {
-	return &inserter{prev: ins, fn: fn}
+	return &inserter{prev: ins, fn: fn, builder: ins.builder}
 }
 
 func (ins *inserter) clone() *inserter {

--- a/lib/sqlbuilder/select.go
+++ b/lib/sqlbuilder/select.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"sync"
 
 	"upper.io/db.v2"
 	"upper.io/db.v2/internal/sqladapter/exql"
@@ -18,11 +17,8 @@ const (
 	selectModeDistinct
 )
 
-type selector struct {
-	*stringer
-
-	mode    selectMode
-	builder *sqlBuilder
+type selectorQuery struct {
+	mode selectMode
 
 	table     *exql.Columns
 	tableArgs []interface{}
@@ -46,334 +42,410 @@ type selector struct {
 
 	joins     []*exql.Join
 	joinsArgs []interface{}
-
-	mu sync.Mutex
-
-	err error
 }
 
-func (qs *selector) From(tables ...interface{}) Selector {
-	f, args, err := columnFragments(qs.builder.t, tables)
+func (sq *selectorQuery) and(terms ...interface{}) error {
+	where, whereArgs := toWhereWithArguments(terms)
+
+	if sq.where == nil {
+		sq.where, sq.whereArgs = &exql.Where{}, []interface{}{}
+	}
+	sq.where.Append(&where)
+	sq.whereArgs = append(sq.whereArgs, whereArgs...)
+
+	return nil
+}
+
+type selector struct {
+	builder *sqlBuilder
+	*stringer
+
+	fn   func(*selectorQuery) error
+	prev *selector
+}
+
+func (sel *selector) Stringer() *stringer {
+	p := &sel
+	for {
+		if (*p).stringer != nil {
+			return (*p).stringer
+		}
+		if (*p).prev == nil {
+			return nil
+		}
+		p = &(*p).prev
+	}
+}
+
+func (sel *selector) String() string {
+	query, err := sel.build()
 	if err != nil {
-		qs.setErr(err)
-		return qs
+		return ""
 	}
-	c := exql.JoinColumns(f...)
-
-	qs.mu.Lock()
-	qs.table = c
-	qs.tableArgs = args
-	qs.mu.Unlock()
-
-	return qs
+	q := sel.Stringer().compileAndReplacePlaceholders(query.statement())
+	q = reInvisibleChars.ReplaceAllString(q, ` `)
+	return strings.TrimSpace(q)
 }
 
-func (qs *selector) Columns(columns ...interface{}) Selector {
-	f, args, err := columnFragments(qs.builder.t, columns)
-	if err != nil {
-		qs.setErr(err)
-		return qs
-	}
-
-	c := exql.JoinColumns(f...)
-
-	qs.mu.Lock()
-	if qs.columns != nil {
-		qs.columns.Append(c)
-	} else {
-		qs.columns = c
-	}
-	qs.columnsArgs = append(qs.columnsArgs, args...)
-	qs.mu.Unlock()
-
-	return qs
+func (sel *selector) frame(fn func(*selectorQuery) error) *selector {
+	return &selector{prev: sel, fn: fn}
 }
 
-func (qs *selector) Distinct() Selector {
-	qs.mu.Lock()
-	qs.mode = selectModeDistinct
-	qs.mu.Unlock()
-	return qs
-}
-
-func (qs *selector) Where(terms ...interface{}) Selector {
-	qs.mu.Lock()
-	qs.where, qs.whereArgs = &exql.Where{}, []interface{}{}
-	qs.mu.Unlock()
-	return qs.And(terms...)
-}
-
-func (qs *selector) And(terms ...interface{}) Selector {
-	where, whereArgs := qs.builder.t.ToWhereWithArguments(terms)
-
-	qs.mu.Lock()
-	if qs.where == nil {
-		qs.where, qs.whereArgs = &exql.Where{}, []interface{}{}
-	}
-	qs.where.Append(&where)
-	qs.whereArgs = append(qs.whereArgs, whereArgs...)
-	qs.mu.Unlock()
-
-	return qs
-}
-
-func (qs *selector) Arguments() []interface{} {
-	qs.mu.Lock()
-	defer qs.mu.Unlock()
-
-	return joinArguments(
-		qs.tableArgs,
-		qs.columnsArgs,
-		qs.joinsArgs,
-		qs.whereArgs,
-		qs.groupByArgs,
-		qs.orderByArgs,
+func (sel *selector) From(tables ...interface{}) Selector {
+	return sel.frame(
+		func(sq *selectorQuery) error {
+			f, args, err := columnFragments(tables)
+			if err != nil {
+				return err
+			}
+			sq.table = exql.JoinColumns(f...)
+			sq.tableArgs = args
+			return nil
+		},
 	)
 }
 
-func (qs *selector) GroupBy(columns ...interface{}) Selector {
-	fragments, args, err := columnFragments(qs.builder.t, columns)
-	if err != nil {
-		qs.setErr(err)
-		return qs
-	}
+func (sel *selector) Columns(columns ...interface{}) Selector {
+	return sel.frame(
+		func(sq *selectorQuery) error {
+			f, args, err := columnFragments(columns)
+			if err != nil {
+				return err
+			}
 
-	qs.mu.Lock()
-	if fragments != nil {
-		qs.groupBy = exql.GroupByColumns(fragments...)
-	}
-	qs.groupByArgs = args
-	qs.mu.Unlock()
+			c := exql.JoinColumns(f...)
 
-	return qs
+			if sq.columns != nil {
+				sq.columns.Append(c)
+			} else {
+				sq.columns = c
+			}
+
+			sq.columnsArgs = append(sq.columnsArgs, args...)
+			return nil
+		},
+	)
 }
 
-func (qs *selector) OrderBy(columns ...interface{}) Selector {
-	var sortColumns exql.SortColumns
+func (sel *selector) Distinct() Selector {
+	return sel.frame(func(sq *selectorQuery) error {
+		sq.mode = selectModeDistinct
+		return nil
+	})
+}
 
-	for i := range columns {
-		var sort *exql.SortColumn
+func (sel *selector) Where(terms ...interface{}) Selector {
+	return sel.frame(func(sq *selectorQuery) error {
+		sq.where, sq.whereArgs = &exql.Where{}, []interface{}{}
+		return sq.and(terms...)
+	})
+}
 
-		switch value := columns[i].(type) {
-		case db.RawValue:
-			col, args := expandPlaceholders(value.Raw(), value.Arguments()...)
-			sort = &exql.SortColumn{
-				Column: exql.RawValue(col),
-			}
-			qs.mu.Lock()
-			qs.orderByArgs = append(qs.orderByArgs, args...)
-			qs.mu.Unlock()
-		case db.Function:
-			fnName, fnArgs := value.Name(), value.Arguments()
-			if len(fnArgs) == 0 {
-				fnName = fnName + "()"
-			} else {
-				fnName = fnName + "(?" + strings.Repeat("?, ", len(fnArgs)-1) + ")"
-			}
-			expanded, fnArgs := expandPlaceholders(fnName, fnArgs...)
-			sort = &exql.SortColumn{
-				Column: exql.RawValue(expanded),
-			}
-			qs.mu.Lock()
-			qs.orderByArgs = append(qs.orderByArgs, fnArgs...)
-			qs.mu.Unlock()
-		case string:
-			if strings.HasPrefix(value, "-") {
-				sort = &exql.SortColumn{
-					Column: exql.ColumnWithName(value[1:]),
-					Order:  exql.Descendent,
-				}
-			} else {
-				chunks := strings.SplitN(value, " ", 2)
+func (sel *selector) And(terms ...interface{}) Selector {
+	return sel.frame(func(sq *selectorQuery) error {
+		sq.and(terms...)
+		return nil
+	})
+}
 
-				order := exql.Ascendent
-				if len(chunks) > 1 && strings.ToUpper(chunks[1]) == "DESC" {
-					order = exql.Descendent
-				}
+func (sq *selectorQuery) arguments() []interface{} {
+	return joinArguments(
+		sq.tableArgs,
+		sq.columnsArgs,
+		sq.joinsArgs,
+		sq.whereArgs,
+		sq.groupByArgs,
+		sq.orderByArgs,
+	)
+}
 
-				sort = &exql.SortColumn{
-					Column: exql.ColumnWithName(chunks[0]),
-					Order:  order,
-				}
-			}
-		default:
-			qs.setErr(fmt.Errorf("Can't sort by type %T", value))
-			return qs
+func (sel *selector) Arguments() []interface{} {
+	sq, err := sel.build()
+	if err != nil {
+		return nil
+	}
+	return sq.arguments()
+}
+
+func (sq *selectorQuery) statement() *exql.Statement {
+	stmt := &exql.Statement{
+		Type:    exql.Select,
+		Table:   sq.table,
+		Columns: sq.columns,
+		Limit:   sq.limit,
+		Offset:  sq.offset,
+		Where:   sq.where,
+		OrderBy: sq.orderBy,
+		GroupBy: sq.groupBy,
+	}
+
+	if len(sq.joins) > 0 {
+		stmt.Joins = exql.JoinConditions(sq.joins...)
+	}
+
+	return stmt
+}
+
+func (sel *selector) GroupBy(columns ...interface{}) Selector {
+	return sel.frame(func(sq *selectorQuery) error {
+		fragments, args, err := columnFragments(columns)
+		if err != nil {
+			return err
 		}
-		sortColumns.Columns = append(sortColumns.Columns, sort)
-	}
 
-	qs.mu.Lock()
-	qs.orderBy = &exql.OrderBy{
-		SortColumns: &sortColumns,
-	}
-	qs.mu.Unlock()
+		if fragments != nil {
+			sq.groupBy = exql.GroupByColumns(fragments...)
+		}
+		sq.groupByArgs = args
 
-	return qs
+		return nil
+	})
 }
 
-func (qs *selector) Using(columns ...interface{}) Selector {
-	qs.mu.Lock()
-	joins := len(qs.joins)
-	qs.mu.Unlock()
+func (sel *selector) OrderBy(columns ...interface{}) Selector {
+	return sel.frame(func(sq *selectorQuery) error {
+		var sortColumns exql.SortColumns
 
-	if joins == 0 {
-		qs.setErr(errors.New(`Cannot use Using() without a preceding Join() expression.`))
-		return qs
-	}
+		for i := range columns {
+			var sort *exql.SortColumn
 
-	lastJoin := qs.joins[joins-1]
-	if lastJoin.On != nil {
-		qs.setErr(errors.New(`Cannot use Using() and On() with the same Join() expression.`))
-		return qs
-	}
+			switch value := columns[i].(type) {
+			case db.RawValue:
+				col, args := expandPlaceholders(value.Raw(), value.Arguments()...)
+				sort = &exql.SortColumn{
+					Column: exql.RawValue(col),
+				}
+				sq.orderByArgs = append(sq.orderByArgs, args...)
+			case db.Function:
+				fnName, fnArgs := value.Name(), value.Arguments()
+				if len(fnArgs) == 0 {
+					fnName = fnName + "()"
+				} else {
+					fnName = fnName + "(?" + strings.Repeat("?, ", len(fnArgs)-1) + ")"
+				}
+				expanded, fnArgs := expandPlaceholders(fnName, fnArgs...)
+				sort = &exql.SortColumn{
+					Column: exql.RawValue(expanded),
+				}
+				sq.orderByArgs = append(sq.orderByArgs, fnArgs...)
+			case string:
+				if strings.HasPrefix(value, "-") {
+					sort = &exql.SortColumn{
+						Column: exql.ColumnWithName(value[1:]),
+						Order:  exql.Descendent,
+					}
+				} else {
+					chunks := strings.SplitN(value, " ", 2)
 
-	fragments, args, err := columnFragments(qs.builder.t, columns)
-	if err != nil {
-		qs.setErr(err)
-		return qs
-	}
+					order := exql.Ascendent
+					if len(chunks) > 1 && strings.ToUpper(chunks[1]) == "DESC" {
+						order = exql.Descendent
+					}
 
-	qs.mu.Lock()
-	qs.joinsArgs = append(qs.joinsArgs, args...)
-	lastJoin.Using = exql.UsingColumns(fragments...)
-	qs.mu.Unlock()
+					sort = &exql.SortColumn{
+						Column: exql.ColumnWithName(chunks[0]),
+						Order:  order,
+					}
+				}
+			default:
+				return fmt.Errorf("Can't sort by type %T", value)
+			}
+			sortColumns.Columns = append(sortColumns.Columns, sort)
+		}
 
-	return qs
+		sq.orderBy = &exql.OrderBy{
+			SortColumns: &sortColumns,
+		}
+		return nil
+	})
 }
 
-func (qs *selector) pushJoin(t string, tables []interface{}) Selector {
+func (sel *selector) Using(columns ...interface{}) Selector {
+	return sel.frame(func(sq *selectorQuery) error {
+
+		joins := len(sq.joins)
+
+		if joins == 0 {
+			return errors.New(`Cannot use Using() without a preceding Join() expression.`)
+		}
+
+		lastJoin := sq.joins[joins-1]
+		if lastJoin.On != nil {
+			return errors.New(`Cannot use Using() and On() with the same Join() expression.`)
+		}
+
+		fragments, args, err := columnFragments(columns)
+		if err != nil {
+			return err
+		}
+
+		sq.joinsArgs = append(sq.joinsArgs, args...)
+		lastJoin.Using = exql.UsingColumns(fragments...)
+
+		return nil
+	})
+}
+
+func (sq *selectorQuery) pushJoin(t string, tables []interface{}) error {
 	tableNames := make([]string, len(tables))
 	for i := range tables {
 		tableNames[i] = fmt.Sprintf("%s", tables[i])
 	}
 
-	qs.mu.Lock()
-	if qs.joins == nil {
-		qs.joins = []*exql.Join{}
+	if sq.joins == nil {
+		sq.joins = []*exql.Join{}
 	}
-	qs.joins = append(qs.joins,
+	sq.joins = append(sq.joins,
 		&exql.Join{
 			Type:  t,
 			Table: exql.TableWithName(strings.Join(tableNames, ", ")),
 		},
 	)
-	qs.mu.Unlock()
 
-	return qs
+	return nil
 }
 
-func (qs *selector) FullJoin(tables ...interface{}) Selector {
-	return qs.pushJoin("FULL", tables)
+func (sel *selector) FullJoin(tables ...interface{}) Selector {
+	return sel.frame(func(sq *selectorQuery) error {
+		return sq.pushJoin("FULL", tables)
+	})
 }
 
-func (qs *selector) CrossJoin(tables ...interface{}) Selector {
-	return qs.pushJoin("CROSS", tables)
+func (sel *selector) CrossJoin(tables ...interface{}) Selector {
+	return sel.frame(func(sq *selectorQuery) error {
+		return sq.pushJoin("CROSS", tables)
+	})
 }
 
-func (qs *selector) RightJoin(tables ...interface{}) Selector {
-	return qs.pushJoin("RIGHT", tables)
+func (sel *selector) RightJoin(tables ...interface{}) Selector {
+	return sel.frame(func(sq *selectorQuery) error {
+		return sq.pushJoin("RIGHT", tables)
+	})
 }
 
-func (qs *selector) LeftJoin(tables ...interface{}) Selector {
-	return qs.pushJoin("LEFT", tables)
+func (sel *selector) LeftJoin(tables ...interface{}) Selector {
+	return sel.frame(func(sq *selectorQuery) error {
+		return sq.pushJoin("LEFT", tables)
+	})
 }
 
-func (qs *selector) Join(tables ...interface{}) Selector {
-	return qs.pushJoin("", tables)
+func (sel *selector) Join(tables ...interface{}) Selector {
+	return sel.frame(func(sq *selectorQuery) error {
+		return sq.pushJoin("", tables)
+	})
 }
 
-func (qs *selector) On(terms ...interface{}) Selector {
-	qs.mu.Lock()
-	joins := len(qs.joins)
-	qs.mu.Unlock()
+func (sel *selector) On(terms ...interface{}) Selector {
+	return sel.frame(func(sq *selectorQuery) error {
+		joins := len(sq.joins)
 
-	if joins == 0 {
-		qs.setErr(errors.New(`Cannot use On() without a preceding Join() expression.`))
-		return qs
+		if joins == 0 {
+			return errors.New(`Cannot use On() without a preceding Join() expression.`)
+		}
+
+		lastJoin := sq.joins[joins-1]
+		if lastJoin.On != nil {
+			return errors.New(`Cannot use Using() and On() with the same Join() expression.`)
+		}
+
+		w, a := toWhereWithArguments(terms)
+		o := exql.On(w)
+
+		lastJoin.On = &o
+
+		sq.joinsArgs = append(sq.joinsArgs, a...)
+
+		return nil
+	})
+}
+
+func (sel *selector) Limit(n int) Selector {
+	return sel.frame(func(sq *selectorQuery) error {
+		sq.limit = exql.Limit(n)
+		return nil
+	})
+}
+
+func (sel *selector) Offset(n int) Selector {
+	return sel.frame(func(sq *selectorQuery) error {
+		sq.offset = exql.Offset(n)
+		return nil
+	})
+}
+
+func (sel *selector) As(alias string) Selector {
+	return sel.frame(func(sq *selectorQuery) error {
+		if sq.table == nil {
+			return errors.New("Cannot use As() without a preceding From() expression")
+		}
+		last := len(sq.table.Columns) - 1
+		if raw, ok := sq.table.Columns[last].(*exql.Raw); ok {
+			sq.table.Columns[last] = exql.RawValue("(" + raw.Value + ") AS " + exql.ColumnWithName(alias).Compile(sel.Stringer().t))
+		}
+		return nil
+	})
+}
+
+func (sel *selector) statement() *exql.Statement {
+	sq, _ := sel.build()
+	return sq.statement()
+}
+
+func (sel *selector) QueryRow() (*sql.Row, error) {
+	sq, err := sel.build()
+	if err != nil {
+		return nil, err
 	}
 
-	lastJoin := qs.joins[joins-1]
-	if lastJoin.On != nil {
-		qs.setErr(errors.New(`Cannot use Using() and On() with the same Join() expression.`))
-		return qs
+	return sel.builder.sess.StatementQueryRow(sq.statement(), sq.arguments()...)
+}
+
+func (sel *selector) Query() (*sql.Rows, error) {
+	sq, err := sel.build()
+	if err != nil {
+		return nil, err
+	}
+	return sel.builder.sess.StatementQuery(sq.statement(), sq.arguments()...)
+}
+
+func (sel *selector) Iterator() Iterator {
+	sq, err := sel.build()
+	if err != nil {
+		return &iterator{nil, err}
 	}
 
-	w, a := qs.builder.t.ToWhereWithArguments(terms)
-	o := exql.On(w)
-
-	lastJoin.On = &o
-
-	qs.mu.Lock()
-	qs.joinsArgs = append(qs.joinsArgs, a...)
-	qs.mu.Unlock()
-
-	return qs
-}
-
-func (qs *selector) Limit(n int) Selector {
-	qs.mu.Lock()
-	qs.limit = exql.Limit(n)
-	qs.mu.Unlock()
-	return qs
-}
-
-func (qs *selector) Offset(n int) Selector {
-	qs.mu.Lock()
-	qs.offset = exql.Offset(n)
-	qs.mu.Unlock()
-	return qs
-}
-
-func (qs *selector) statement() *exql.Statement {
-	return &exql.Statement{
-		Type:    exql.Select,
-		Table:   qs.table,
-		Columns: qs.columns,
-		Limit:   qs.limit,
-		Offset:  qs.offset,
-		Joins:   exql.JoinConditions(qs.joins...),
-		Where:   qs.where,
-		OrderBy: qs.orderBy,
-		GroupBy: qs.groupBy,
-	}
-}
-
-func (qs *selector) Query() (*sql.Rows, error) {
-	return qs.builder.sess.StatementQuery(qs.statement(), qs.Arguments()...)
-}
-
-func (qs *selector) As(alias string) Selector {
-	if qs.table == nil {
-		qs.setErr(errors.New("Cannot use As() without a preceding From() expression"))
-		return qs
-	}
-	last := len(qs.table.Columns) - 1
-	if raw, ok := qs.table.Columns[last].(*exql.Raw); ok {
-		qs.table.Columns[last] = exql.RawValue("(" + raw.Value + ") AS " + exql.ColumnWithName(alias).Compile(qs.stringer.t))
-	}
-	return qs
-}
-
-func (qs *selector) QueryRow() (*sql.Row, error) {
-	return qs.builder.sess.StatementQueryRow(qs.statement(), qs.Arguments()...)
-}
-
-func (qs *selector) Iterator() Iterator {
-	rows, err := qs.builder.sess.StatementQuery(qs.statement(), qs.Arguments()...)
+	rows, err := sel.builder.sess.StatementQuery(sq.statement(), sq.arguments()...)
 	return &iterator{rows, err}
 }
 
-func (qs *selector) All(destSlice interface{}) error {
-	return qs.Iterator().All(destSlice)
+func (sel *selector) All(destSlice interface{}) error {
+	return sel.Iterator().All(destSlice)
 }
 
-func (qs *selector) One(dest interface{}) error {
-	return qs.Iterator().One(dest)
+func (sel *selector) One(dest interface{}) error {
+	return sel.Iterator().One(dest)
 }
 
-func (qs *selector) setErr(err error) {
-	qs.mu.Lock()
-	qs.err = err
-	qs.mu.Unlock()
+func (sel *selector) build() (*selectorQuery, error) {
+	sq, err := selectorFastForward(&selectorQuery{}, sel)
+	if err != nil {
+		return nil, err
+	}
+	return sq, nil
+}
+
+func (sel *selector) Compile() string {
+	return sel.statement().Compile(sel.Stringer().t)
+}
+
+func selectorFastForward(in *selectorQuery, curr *selector) (*selectorQuery, error) {
+	if curr == nil || curr.fn == nil {
+		return in, nil
+	}
+	in, err := selectorFastForward(in, curr.prev)
+	if err != nil {
+		return nil, err
+	}
+	err = curr.fn(in)
+	return in, err
 }

--- a/lib/sqlbuilder/select.go
+++ b/lib/sqlbuilder/select.go
@@ -243,9 +243,9 @@ func (sel *selector) OrderBy(columns ...interface{}) Selector {
 
 			switch value := columns[i].(type) {
 			case db.RawValue:
-				col, args := expandPlaceholders(value.Raw(), value.Arguments())
+				query, args := Preprocess(value.Raw(), value.Arguments())
 				sort = &exql.SortColumn{
-					Column: exql.RawValue(col),
+					Column: exql.RawValue(query),
 				}
 				sq.orderByArgs = append(sq.orderByArgs, args...)
 			case db.Function:
@@ -255,9 +255,9 @@ func (sel *selector) OrderBy(columns ...interface{}) Selector {
 				} else {
 					fnName = fnName + "(?" + strings.Repeat("?, ", len(fnArgs)-1) + ")"
 				}
-				expanded, fnArgs := expandPlaceholders(fnName, fnArgs)
+				fnName, fnArgs = Preprocess(fnName, fnArgs)
 				sort = &exql.SortColumn{
-					Column: exql.RawValue(expanded),
+					Column: exql.RawValue(fnName),
 				}
 				sq.orderByArgs = append(sq.orderByArgs, fnArgs...)
 			case string:

--- a/lib/sqlbuilder/select.go
+++ b/lib/sqlbuilder/select.go
@@ -113,6 +113,19 @@ type selector struct {
 	prev *selector
 }
 
+func (sel *selector) Builder() *sqlBuilder {
+	p := &sel
+	for {
+		if (*p).builder != nil {
+			return (*p).builder
+		}
+		if (*p).prev == nil {
+			return nil
+		}
+		p = &(*p).prev
+	}
+}
+
 func (sel *selector) Stringer() *stringer {
 	p := &sel
 	for {
@@ -397,7 +410,7 @@ func (sel *selector) QueryRow() (*sql.Row, error) {
 		return nil, err
 	}
 
-	return sel.builder.sess.StatementQueryRow(sq.statement(), sq.arguments()...)
+	return sel.Builder().sess.StatementQueryRow(sq.statement(), sq.arguments()...)
 }
 
 func (sel *selector) Query() (*sql.Rows, error) {
@@ -405,7 +418,7 @@ func (sel *selector) Query() (*sql.Rows, error) {
 	if err != nil {
 		return nil, err
 	}
-	return sel.builder.sess.StatementQuery(sq.statement(), sq.arguments()...)
+	return sel.Builder().sess.StatementQuery(sq.statement(), sq.arguments()...)
 }
 
 func (sel *selector) Iterator() Iterator {
@@ -414,7 +427,7 @@ func (sel *selector) Iterator() Iterator {
 		return &iterator{nil, err}
 	}
 
-	rows, err := sel.builder.sess.StatementQuery(sq.statement(), sq.arguments()...)
+	rows, err := sel.Builder().sess.StatementQuery(sq.statement(), sq.arguments()...)
 	return &iterator{rows, err}
 }
 

--- a/lib/sqlbuilder/update.go
+++ b/lib/sqlbuilder/update.go
@@ -46,7 +46,7 @@ func (qu *updater) Set(terms ...interface{}) Updater {
 		qu.columnValues.Insert(cvs...)
 		qu.columnValuesArgs = append(qu.columnValuesArgs, args...)
 	} else if len(terms) > 1 {
-		cv, arguments := qu.builder.t.ToColumnValues(terms)
+		cv, arguments := toColumnValues(terms)
 		qu.columnValues.Insert(cv.ColumnValues...)
 		qu.columnValuesArgs = append(qu.columnValuesArgs, arguments...)
 	}
@@ -65,7 +65,7 @@ func (qu *updater) Arguments() []interface{} {
 }
 
 func (qu *updater) Where(terms ...interface{}) Updater {
-	where, arguments := qu.builder.t.ToWhereWithArguments(terms)
+	where, arguments := toWhereWithArguments(terms)
 	qu.where = &where
 	qu.whereArgs = append(qu.whereArgs, arguments...)
 	return qu

--- a/lib/sqlbuilder/update.go
+++ b/lib/sqlbuilder/update.go
@@ -158,7 +158,7 @@ func (upd *updater) Exec() (sql.Result, error) {
 	if err != nil {
 		return nil, err
 	}
-	return upd.builder.sess.StatementExec(uq.statement(), uq.arguments()...)
+	return upd.Builder().sess.StatementExec(uq.statement(), uq.arguments()...)
 }
 
 func (upd *updater) Limit(limit int) Updater {

--- a/lib/sqlbuilder/update.go
+++ b/lib/sqlbuilder/update.go
@@ -2,15 +2,13 @@ package sqlbuilder
 
 import (
 	"database/sql"
-	"sync"
+	"strings"
 
 	"upper.io/db.v2/internal/sqladapter/exql"
 )
 
-type updater struct {
-	*stringer
-	builder *sqlBuilder
-	table   string
+type updaterQuery struct {
+	table string
 
 	columnValues     *exql.ColumnValues
 	columnValuesArgs []interface{}
@@ -19,81 +17,182 @@ type updater struct {
 
 	where     *exql.Where
 	whereArgs []interface{}
-
-	mu sync.Mutex
 }
 
-func (qu *updater) Set(terms ...interface{}) Updater {
-	if len(terms) == 1 {
-		ff, vv, _ := Map(terms[0], nil)
-
-		cvs := make([]exql.Fragment, 0, len(ff))
-		args := make([]interface{}, 0, len(vv))
-
-		for i := range ff {
-			cv := &exql.ColumnValue{
-				Column:   exql.ColumnWithName(ff[i]),
-				Operator: qu.builder.t.AssignmentOperator,
-			}
-
-			var localArgs []interface{}
-			cv.Value, localArgs = qu.builder.t.PlaceholderValue(vv[i])
-
-			args = append(args, localArgs...)
-			cvs = append(cvs, cv)
-		}
-
-		qu.columnValues.Insert(cvs...)
-		qu.columnValuesArgs = append(qu.columnValuesArgs, args...)
-	} else if len(terms) > 1 {
-		cv, arguments := toColumnValues(terms)
-		qu.columnValues.Insert(cv.ColumnValues...)
-		qu.columnValuesArgs = append(qu.columnValuesArgs, arguments...)
-	}
-
-	return qu
-}
-
-func (qu *updater) Arguments() []interface{} {
-	qu.mu.Lock()
-	defer qu.mu.Unlock()
-
-	return joinArguments(
-		qu.columnValuesArgs,
-		qu.whereArgs,
-	)
-}
-
-func (qu *updater) Where(terms ...interface{}) Updater {
-	where, arguments := toWhereWithArguments(terms)
-	qu.where = &where
-	qu.whereArgs = append(qu.whereArgs, arguments...)
-	return qu
-}
-
-func (qu *updater) Exec() (sql.Result, error) {
-	return qu.builder.sess.StatementExec(qu.statement(), qu.Arguments()...)
-}
-
-func (qu *updater) Limit(limit int) Updater {
-	qu.limit = limit
-	return qu
-}
-
-func (qu *updater) statement() *exql.Statement {
+func (uq *updaterQuery) statement() *exql.Statement {
 	stmt := &exql.Statement{
 		Type:         exql.Update,
-		Table:        exql.TableWithName(qu.table),
-		ColumnValues: qu.columnValues,
+		Table:        exql.TableWithName(uq.table),
+		ColumnValues: uq.columnValues,
 	}
 
-	if qu.Where != nil {
-		stmt.Where = qu.where
+	if uq.where != nil {
+		stmt.Where = uq.where
 	}
 
-	if qu.limit != 0 {
-		stmt.Limit = exql.Limit(qu.limit)
+	if uq.limit != 0 {
+		stmt.Limit = exql.Limit(uq.limit)
 	}
 
 	return stmt
+}
+
+func (uq *updaterQuery) arguments() []interface{} {
+	return joinArguments(
+		uq.columnValuesArgs,
+		uq.whereArgs,
+	)
+}
+
+type updater struct {
+	*stringer
+	builder *sqlBuilder
+
+	fn   func(*updaterQuery) error
+	prev *updater
+}
+
+func (upd *updater) Builder() *sqlBuilder {
+	p := &upd
+	for {
+		if (*p).builder != nil {
+			return (*p).builder
+		}
+		if (*p).prev == nil {
+			return nil
+		}
+		p = &(*p).prev
+	}
+}
+
+func (upd *updater) Stringer() *stringer {
+	p := &upd
+	for {
+		if (*p).stringer != nil {
+			return (*p).stringer
+		}
+		if (*p).prev == nil {
+			return nil
+		}
+		p = &(*p).prev
+	}
+}
+
+func (upd *updater) String() string {
+	query, err := upd.build()
+	if err != nil {
+		return ""
+	}
+	q := upd.Stringer().compileAndReplacePlaceholders(query.statement())
+	q = reInvisibleChars.ReplaceAllString(q, ` `)
+	return strings.TrimSpace(q)
+}
+
+func (upd *updater) setTable(table string) *updater {
+	return upd.frame(func(uq *updaterQuery) error {
+		uq.table = table
+		return nil
+	})
+}
+
+func (upd *updater) frame(fn func(*updaterQuery) error) *updater {
+	return &updater{prev: upd, fn: fn}
+}
+
+func (upd *updater) Set(terms ...interface{}) Updater {
+	return upd.frame(func(uq *updaterQuery) error {
+		if uq.columnValues == nil {
+			uq.columnValues = &exql.ColumnValues{}
+		}
+
+		if len(terms) == 1 {
+			ff, vv, _ := Map(terms[0], nil)
+
+			cvs := make([]exql.Fragment, 0, len(ff))
+			args := make([]interface{}, 0, len(vv))
+
+			for i := range ff {
+				cv := &exql.ColumnValue{
+					Column:   exql.ColumnWithName(ff[i]),
+					Operator: upd.Builder().t.AssignmentOperator,
+				}
+
+				var localArgs []interface{}
+				cv.Value, localArgs = upd.Builder().t.PlaceholderValue(vv[i])
+
+				args = append(args, localArgs...)
+				cvs = append(cvs, cv)
+			}
+
+			uq.columnValues.Insert(cvs...)
+			uq.columnValuesArgs = append(uq.columnValuesArgs, args...)
+		} else if len(terms) > 1 {
+			cv, arguments := toColumnValues(terms)
+			uq.columnValues.Insert(cv.ColumnValues...)
+			uq.columnValuesArgs = append(uq.columnValuesArgs, arguments...)
+		}
+
+		return nil
+	})
+}
+
+func (upd *updater) Arguments() []interface{} {
+	uq, err := upd.build()
+	if err != nil {
+		return nil
+	}
+	return uq.arguments()
+}
+
+func (upd *updater) Where(terms ...interface{}) Updater {
+	return upd.frame(func(uq *updaterQuery) error {
+		where, arguments := toWhereWithArguments(terms)
+		uq.where = &where
+		uq.whereArgs = append(uq.whereArgs, arguments...)
+		return nil
+	})
+}
+
+func (upd *updater) Exec() (sql.Result, error) {
+	uq, err := upd.build()
+	if err != nil {
+		return nil, err
+	}
+	return upd.builder.sess.StatementExec(uq.statement(), uq.arguments()...)
+}
+
+func (upd *updater) Limit(limit int) Updater {
+	return upd.frame(func(uq *updaterQuery) error {
+		uq.limit = limit
+		return nil
+	})
+}
+
+func (upd *updater) statement() *exql.Statement {
+	iq, _ := upd.build()
+	return iq.statement()
+}
+
+func (upd *updater) build() (*updaterQuery, error) {
+	iq, err := updaterFastForward(&updaterQuery{}, upd)
+	if err != nil {
+		return nil, err
+	}
+	return iq, nil
+}
+
+func (upd *updater) Compile() string {
+	return upd.statement().Compile(upd.Stringer().t)
+}
+
+func updaterFastForward(in *updaterQuery, curr *updater) (*updaterQuery, error) {
+	if curr == nil || curr.fn == nil {
+		return in, nil
+	}
+	in, err := updaterFastForward(in, curr.prev)
+	if err != nil {
+		return nil, err
+	}
+	err = curr.fn(in)
+	return in, err
 }

--- a/postgresql/collection.go
+++ b/postgresql/collection.go
@@ -102,7 +102,7 @@ func (t *table) Insert(item interface{}) (interface{}, error) {
 	}
 
 	// Asking the database to return the primary key after insertion.
-	q.Returning(pKey...)
+	q = q.Returning(pKey...)
 
 	var keyMap db.Cond
 	if err = q.Iterator().One(&keyMap); err != nil {


### PR DESCRIPTION
This PR introduces a (breaking change) in which statements no longer mutate themselves.

Supports SQL builder, col.Find() stuff (`db.Result`), and `db.And`/`db.Or`.

There's also a tool that can help spotting statements that are not getting reassigned: https://github.com/upper/cmd/tree/master/dbcheck, we can use that tool to fix orphan statements on existent codebases.

Closes https://github.com/upper/db/issues/296