### PR TITLE
WIP: Better support for raw queries and subqueries.

### DIFF
--- a/lib/sqlbuilder/placeholder_test.go
+++ b/lib/sqlbuilder/placeholder_test.go
@@ -9,74 +9,74 @@ import (
 
 func TestPlaceholderSimple(t *testing.T) {
 	{
-		ret, _ := expandPlaceholders("?", 1)
+		ret, _ := Preprocess("?", []interface{}{1})
 		assert.Equal(t, "?", ret)
 	}
 	{
-		ret, _ := expandPlaceholders("?")
+		ret, _ := Preprocess("?", nil)
 		assert.Equal(t, "?", ret)
 	}
 }
 
 func TestPlaceholderMany(t *testing.T) {
 	{
-		ret, _ := expandPlaceholders("?, ?, ?", 1, 2, 3)
+		ret, _ := Preprocess("?, ?, ?", []interface{}{1, 2, 3})
 		assert.Equal(t, "?, ?, ?", ret)
 	}
 }
 
 func TestPlaceholderArray(t *testing.T) {
 	{
-		ret, _ := expandPlaceholders("?, ?, ?", 1, 2, []interface{}{3, 4, 5})
+		ret, _ := Preprocess("?, ?, ?", []interface{}{1, 2, []interface{}{3, 4, 5}})
 		assert.Equal(t, "?, ?, (?, ?, ?)", ret)
 	}
 
 	{
-		ret, _ := expandPlaceholders("?, ?, ?", []interface{}{1, 2, 3}, 4, 5)
+		ret, _ := Preprocess("?, ?, ?", []interface{}{[]interface{}{1, 2, 3}, 4, 5})
 		assert.Equal(t, "(?, ?, ?), ?, ?", ret)
 	}
 
 	{
-		ret, _ := expandPlaceholders("?, ?, ?", 1, []interface{}{2, 3, 4}, 5)
+		ret, _ := Preprocess("?, ?, ?", []interface{}{1, []interface{}{2, 3, 4}, 5})
 		assert.Equal(t, "?, (?, ?, ?), ?", ret)
 	}
 
 	{
-		ret, _ := expandPlaceholders("???", 1, []interface{}{2, 3, 4}, 5)
+		ret, _ := Preprocess("???", []interface{}{1, []interface{}{2, 3, 4}, 5})
 		assert.Equal(t, "?(?, ?, ?)?", ret)
 	}
 
 	{
-		ret, _ := expandPlaceholders("??", []interface{}{1, 2, 3}, []interface{}{}, []interface{}{4, 5}, []interface{}{})
+		ret, _ := Preprocess("??", []interface{}{[]interface{}{1, 2, 3}, []interface{}{}, []interface{}{4, 5}, []interface{}{}})
 		assert.Equal(t, "(?, ?, ?)(NULL)", ret)
 	}
 }
 
 func TestPlaceholderArguments(t *testing.T) {
 	{
-		_, args := expandPlaceholders("?, ?, ?", 1, 2, []interface{}{3, 4, 5})
+		_, args := Preprocess("?, ?, ?", []interface{}{1, 2, []interface{}{3, 4, 5}})
 		assert.Equal(t, []interface{}{1, 2, 3, 4, 5}, args)
 	}
 
 	{
-		_, args := expandPlaceholders("?, ?, ?", 1, []interface{}{2, 3, 4}, 5)
+		_, args := Preprocess("?, ?, ?", []interface{}{1, []interface{}{2, 3, 4}, 5})
 		assert.Equal(t, []interface{}{1, 2, 3, 4, 5}, args)
 	}
 
 	{
-		_, args := expandPlaceholders("?, ?, ?", []interface{}{1, 2, 3}, 4, 5)
+		_, args := Preprocess("?, ?, ?", []interface{}{[]interface{}{1, 2, 3}, 4, 5})
 		assert.Equal(t, []interface{}{1, 2, 3, 4, 5}, args)
 	}
 
 	{
-		_, args := expandPlaceholders("?, ?", []interface{}{1, 2, 3}, []interface{}{4, 5})
+		_, args := Preprocess("?, ?", []interface{}{[]interface{}{1, 2, 3}, []interface{}{4, 5}})
 		assert.Equal(t, []interface{}{1, 2, 3, 4, 5}, args)
 	}
 }
 
 func TestPlaceholderReplace(t *testing.T) {
 	{
-		ret, args := expandPlaceholders("?, ?, ?", 1, db.Raw("foo"), 3)
+		ret, args := Preprocess("?, ?, ?", []interface{}{1, db.Raw("foo"), 3})
 		assert.Equal(t, "?, foo, ?", ret)
 		assert.Equal(t, []interface{}{1, 3}, args)
 	}

--- a/lib/sqlbuilder/select.go
+++ b/lib/sqlbuilder/select.go
@@ -156,7 +156,7 @@ func (qs *selector) OrderBy(columns ...interface{}) Selector {
 
 		switch value := columns[i].(type) {
 		case db.RawValue:
-			col, args := expandPlaceholders(value.Raw(), value.Arguments()...)
+			col, args := expandPlaceholders(value.Raw(), value.Arguments())
 			sort = &exql.SortColumn{
 				Column: exql.RawValue(col),
 			}
@@ -170,7 +170,7 @@ func (qs *selector) OrderBy(columns ...interface{}) Selector {
 			} else {
 				fnName = fnName + "(?" + strings.Repeat("?, ", len(fnArgs)-1) + ")"
 			}
-			expanded, fnArgs := expandPlaceholders(fnName, fnArgs...)
+			expanded, fnArgs := expandPlaceholders(fnName, fnArgs)
 			sort = &exql.SortColumn{
 				Column: exql.RawValue(expanded),
 			}

--- a/mysql/database.go
+++ b/mysql/database.go
@@ -149,8 +149,8 @@ func (d *database) clone() (*database, error) {
 
 // CompileStatement allows sqladapter to compile the given statement into the
 // format MySQL expects.
-func (d *database) CompileStatement(stmt *exql.Statement) string {
-	return stmt.Compile(template)
+func (d *database) CompileStatement(stmt *exql.Statement, args []interface{}) (string, []interface{}) {
+	return sqlbuilder.Preprocess(stmt.Compile(template), args)
 }
 
 // Err allows sqladapter to translate some known errors into generic errors.

--- a/postgresql/database.go
+++ b/postgresql/database.go
@@ -148,8 +148,9 @@ func (d *database) clone() (*database, error) {
 
 // CompileStatement allows sqladapter to compile the given statement into the
 // format PostgreSQL expects.
-func (d *database) CompileStatement(stmt *exql.Statement) string {
-	return sqladapter.ReplaceWithDollarSign(stmt.Compile(template))
+func (d *database) CompileStatement(stmt *exql.Statement, args []interface{}) (string, []interface{}) {
+	query, args := sqlbuilder.Preprocess(stmt.Compile(template), args)
+	return sqladapter.ReplaceWithDollarSign(query), args
 }
 
 // Err allows sqladapter to translate some known errors into generic errors.

--- a/ql/database.go
+++ b/ql/database.go
@@ -227,8 +227,9 @@ func (d *database) clone() (*database, error) {
 
 // CompileStatement allows sqladapter to compile the given statement into the
 // format SQLite expects.
-func (d *database) CompileStatement(stmt *exql.Statement) string {
-	return sqladapter.ReplaceWithDollarSign(stmt.Compile(template))
+func (d *database) CompileStatement(stmt *exql.Statement, args []interface{}) (string, []interface{}) {
+	query, args := sqlbuilder.Preprocess(stmt.Compile(template), args)
+	return sqladapter.ReplaceWithDollarSign(query), args
 }
 
 // Err allows sqladapter to translate some known errors into generic errors.

--- a/sqlite/database.go
+++ b/sqlite/database.go
@@ -169,8 +169,8 @@ func (d *database) clone() (*database, error) {
 
 // CompileStatement allows sqladapter to compile the given statement into the
 // format SQLite expects.
-func (d *database) CompileStatement(stmt *exql.Statement) string {
-	return stmt.Compile(template)
+func (d *database) CompileStatement(stmt *exql.Statement, args []interface{}) (string, []interface{}) {
+	return sqlbuilder.Preprocess(stmt.Compile(template), args)
 }
 
 // Err allows sqladapter to translate some known errors into generic errors.


### PR DESCRIPTION
This PR provides support for queries like:

```sql
res, err := sess.Query("WITH new_users AS (?) ?",
  sess.InsertInto(...).Returning(...),
  sess.Update(...).Where(...),
)
```

With automatic subquery expansion:

```sql
WITH new_users AS (
  INSERT INTO ... RETURNING id, email 
)    UPDATE another_table
SET user_id = new_users.id
WHERE email = new_users.email
```