### PR TITLE
PostgresSQL OID regclass quotes

### DIFF
--- a/postgresql/database.go
+++ b/postgresql/database.go
@@ -239,7 +239,7 @@ func (d *database) FindTablePrimaryKeys(tableName string) ([]string, error) {
 	q := d.Select("pg_attribute.attname AS pkey").
 		From("pg_index", "pg_class", "pg_attribute").
 		Where(`
-			pg_class.oid = '"` + tableName + `"'::regclass
+			pg_class.oid = '` + tableName + `'::regclass
 			AND indrelid = pg_class.oid
 			AND pg_attribute.attrelid = pg_class.oid
 			AND pg_attribute.attnum = ANY(pg_index.indkey)


### PR DESCRIPTION
Double quotes were being included in the input to `::regclass` causing the table [OID](https://www.postgresql.org/docs/current/static/datatype-oid.html) to never be found.

This failed silently because of #310.