### PR TITLE
Add Amend method and tests.

### DIFF
--- a/internal/sqladapter/testing/adapter.go.tpl
+++ b/internal/sqladapter/testing/adapter.go.tpl
@@ -1294,7 +1294,16 @@ func TestBatchInsert(t *testing.T) {
 		err := sess.Collection("artist").Truncate()
 		assert.NoError(t, err)
 
-		batch := sess.InsertInto("artist").Columns("name").Batch(batchSize)
+		q := sess.InsertInto("artist").Columns("name")
+
+		if Adapter == "postgresql" {
+			q = q.Amend(func(query string) string {
+				return query + ` ON CONFLICT DO NOTHING`
+			})
+		}
+
+
+		batch := q.Batch(batchSize)
 
 		totalItems := int(rand.Int31n(21))
 

--- a/lib/sqlbuilder/delete.go
+++ b/lib/sqlbuilder/delete.go
@@ -13,6 +13,7 @@ type deleter struct {
 	limit     int
 	where     *exql.Where
 	arguments []interface{}
+	amendFn   func(string) string
 }
 
 func (qd *deleter) Where(terms ...interface{}) Deleter {
@@ -24,6 +25,11 @@ func (qd *deleter) Where(terms ...interface{}) Deleter {
 
 func (qd *deleter) Limit(limit int) Deleter {
 	qd.limit = limit
+	return qd
+}
+
+func (qd *deleter) Amend(fn func(string) string) Deleter {
+	qd.amendFn = fn
 	return qd
 }
 
@@ -48,6 +54,8 @@ func (qd *deleter) statement() *exql.Statement {
 	if qd.limit != 0 {
 		stmt.Limit = exql.Limit(qd.limit)
 	}
+
+	stmt.SetAmendment(qd.amendFn)
 
 	return stmt
 }

--- a/lib/sqlbuilder/interfaces.go
+++ b/lib/sqlbuilder/interfaces.go
@@ -279,6 +279,10 @@ type Selector interface {
 	// return results.
 	Offset(int) Selector
 
+	// Amend lets you alter the query's text just before sending it to the
+	// database server.
+	Amend(func(queryIn string) (queryOut string)) Selector
+
 	// Iterator provides methods to iterate over the results returned by the
 	// Selector.
 	Iterator() Iterator
@@ -330,6 +334,10 @@ type Inserter interface {
 	// Inserter. This is only possible when using Returning().
 	Iterator() Iterator
 
+	// Amend lets you alter the query's text just before sending it to the
+	// database server.
+	Amend(func(queryIn string) (queryOut string)) Inserter
+
 	// Batch provies a BatchInserter that can be used to insert many elements at
 	// once by issuing several calls to Values(). It accepts a size parameter
 	// which defines the batch size. If size is < 1, the batch size is set to 1.
@@ -358,6 +366,10 @@ type Deleter interface {
 	//
 	// See Selector.Limit for documentation and usage examples.
 	Limit(int) Deleter
+
+	// Amend lets you alter the query's text just before sending it to the
+	// database server.
+	Amend(func(queryIn string) (queryOut string)) Deleter
 
 	// Execer provides the Exec method.
 	Execer
@@ -394,6 +406,10 @@ type Updater interface {
 
 	// Arguments returns the arguments that are prepared for this query.
 	Arguments() []interface{}
+
+	// Amend lets you alter the query's text just before sending it to the
+	// database server.
+	Amend(func(queryIn string) (queryOut string)) Updater
 }
 
 // Execer provides methods for executing statements that do not return results.

--- a/lib/sqlbuilder/update.go
+++ b/lib/sqlbuilder/update.go
@@ -20,6 +20,8 @@ type updater struct {
 	where     *exql.Where
 	whereArgs []interface{}
 
+	amendFn func(string) string
+
 	mu sync.Mutex
 }
 
@@ -55,6 +57,11 @@ func (qu *updater) Set(columns ...interface{}) Updater {
 	qu.columnValues.Insert(cv.ColumnValues...)
 	qu.columnValuesArgs = append(qu.columnValuesArgs, arguments...)
 
+	return qu
+}
+
+func (qu *updater) Amend(fn func(string) string) Updater {
+	qu.amendFn = fn
 	return qu
 }
 
@@ -98,6 +105,8 @@ func (qu *updater) statement() *exql.Statement {
 	if qu.limit != 0 {
 		stmt.Limit = exql.Limit(qu.limit)
 	}
+
+	stmt.SetAmendment(qu.amendFn)
 
 	return stmt
 }


### PR DESCRIPTION
This commit adds a new `Amend()` method to the query builder, this method allows the user to change a query before executing it, this is specially useful when queries need to be wrapper with particular database extensions, like PostgreSQL's `ON CONFLICT` or `RETURNING`.

See https://github.com/upper/db/pull/298