### PR TITLE
Don't allow nil values on empty arrays.

### DIFF
--- a/lib/sqlbuilder/scanner.go
+++ b/lib/sqlbuilder/scanner.go
@@ -89,7 +89,7 @@ type stringArray []string
 
 func (a *stringArray) Scan(src interface{}) error {
 	if src == nil {
-		*a = nil
+		*a = stringArray{}
 		return nil
 	}
 
@@ -98,7 +98,6 @@ func (a *stringArray) Scan(src interface{}) error {
 		return errors.New("Scan source was not []bytes")
 	}
 	if len(b) == 0 {
-		*a = nil
 		return nil
 	}
 
@@ -222,7 +221,7 @@ type int64Array []int64
 
 func (a *int64Array) Scan(src interface{}) error {
 	if src == nil {
-		*a = nil
+		*a = int64Array{}
 		return nil
 	}
 	b, ok := src.([]byte)
@@ -230,7 +229,6 @@ func (a *int64Array) Scan(src interface{}) error {
 		return errors.New("Scan source was not []bytes")
 	}
 	if len(b) == 0 {
-		*a = nil
 		return nil
 	}
 

--- a/postgresql/adapter_test.go
+++ b/postgresql/adapter_test.go
@@ -470,7 +470,18 @@ func TestPgTypes(t *testing.T) {
 
 			expected := pgTypeTests[i]
 			expected.ID = id.(int64)
-			assert.Equal(t, expected, actual)
+
+			// db.v2: db.v2 forces empty arrays instead of nil values.
+			assert.Equal(t, expected.ID, actual.ID)
+			assert.Equal(t, expected.Field1, actual.Field1)
+			assert.Equal(t, expected.Field2, actual.Field2)
+			assert.Equal(t, expected.Field3, actual.Field3)
+			assert.Equal(t, expected.StringValue, actual.StringValue)
+			assert.Equal(t, len(expected.IntegerArray), len(actual.IntegerArray))
+			assert.Equal(t, len(expected.StringArray), len(actual.StringArray))
+
+			// db.v3: This will be the expected behaviour on db.v3.
+			// assert.Equal(t, expected, actual)
 		}
 
 		for i := range pgTypeTests {
@@ -488,7 +499,17 @@ func TestPgTypes(t *testing.T) {
 			expected := pgTypeTests[i]
 			expected.ID = id
 
-			assert.Equal(t, expected, actual)
+			// db.v2: db.v2 forces empty arrays instead of nil values.
+			assert.Equal(t, expected.ID, actual.ID)
+			assert.Equal(t, expected.Field1, actual.Field1)
+			assert.Equal(t, expected.Field2, actual.Field2)
+			assert.Equal(t, expected.Field3, actual.Field3)
+			assert.Equal(t, expected.StringValue, actual.StringValue)
+			assert.Equal(t, len(expected.IntegerArray), len(actual.IntegerArray))
+			assert.Equal(t, len(expected.StringArray), len(actual.StringArray))
+
+			// db.v3: This will be the expected behaviour on db.v3.
+			// assert.Equal(t, expected, actual)
 		}
 
 		inserter := sess.InsertInto("pg_types")

--- a/postgresql/local_test.go
+++ b/postgresql/local_test.go
@@ -39,21 +39,26 @@ func TestStringAndInt64Array(t *testing.T) {
 	tt := []arrayType{
 		// Test nil arrays.
 		arrayType{
-			ID:       1,
+			ID: 1,
+		},
+
+		// Test nil arrays.
+		arrayType{
+			ID:       2,
 			Integers: nil,
 			Strings:  nil,
 		},
 
 		// Test empty arrays.
 		arrayType{
-			ID:       2,
+			ID:       3,
 			Integers: []int64{},
 			Strings:  []string{},
 		},
 
 		// Test non-empty arrays.
 		arrayType{
-			ID:       3,
+			ID:       4,
 			Integers: []int64{1, 2, 3},
 			Strings:  []string{"1", "2", "3"},
 		},
@@ -70,10 +75,19 @@ func TestStringAndInt64Array(t *testing.T) {
 		var itemCheck arrayType
 		err = arrayTypes.Find(db.Cond{"id": id}).One(&itemCheck)
 		assert.NoError(t, err)
+
 		assert.Len(t, itemCheck.Integers, len(item.Integers))
 		assert.Len(t, itemCheck.Strings, len(item.Strings))
 
-		assert.Equal(t, item, itemCheck)
+		// db.v2: Check nil/zero values just to make sure that the arrays won't be
+		// JSON-marshalled into `null` instead of empty array `[]`.
+		assert.NotNil(t, itemCheck.Integers)
+		assert.NotNil(t, itemCheck.Strings)
+		assert.NotZero(t, itemCheck.Integers)
+		assert.NotZero(t, itemCheck.Strings)
+
+		// db.v3: This will be the expected behaviour on db.v3.
+		//assert.Equal(t, item, itemCheck)
 	}
 }
 


### PR DESCRIPTION
While working on https://github.com/upper/db/issues/328 I found that we had an in inconsistency with `stringarray` and `int64array`, the problem is that if you use those types there's no guarantee that `nil` values will be treated as `nil` when you pull them from the database, this is because `stringarray` and `int64array` will create an empty array instead of keeping a nil value, we wanted to prevent problems with clients that receive marshaled JSON values and may get confused when getting `null` instead of `[]`.

I think that upper should not make an assumption on the user using JSON to marshal/unmarshal database values, to me the most consistent thing would be:

1. User inserts something into the database.
2. User gets something from the database.
3. Outputs in 1 and 2 are equal.

This PR reverts the fix I committed to db.v2 and keeps the old behavior (creating an empty array instead of nil), we'll gonna take proper care of this on db.v3.

