### PR TITLE
postgres connection url should respect port

### DIFF
--- a/postgresql/connection.go
+++ b/postgresql/connection.go
@@ -167,11 +167,16 @@ func ParseURL(s string) (u ConnectionURL, err error) {
 	u.Password = o.Get("password")
 
 	h := o.Get("host")
+	p := o.Get("port")
 
 	if strings.HasPrefix(h, "/") {
 		u.Socket = h
 	} else {
-		u.Host = h
+		if p == "" {
+			u.Host = h
+		} else {
+			u.Host = fmt.Sprintf("%s:%s", h, p)
+		}
 	}
 
 	u.Database = o.Get("dbname")

--- a/postgresql/connection_test.go
+++ b/postgresql/connection_test.go
@@ -88,8 +88,34 @@ func TestParseConnectionURL(t *testing.T) {
 	var s string
 	var err error
 
-	s = "postgres://anakin:skywalker@localhost:1234/jedis"
+	s = "postgres://anakin:skywalker@localhost/jedis"
 
+	if u, err = ParseURL(s); err != nil {
+		t.Fatal(err)
+	}
+
+	if u.User != "anakin" {
+		t.Fatal("Failed to parse username.")
+	}
+
+	if u.Password != "skywalker" {
+		t.Fatal("Failed to parse password.")
+	}
+
+	if u.Host != "localhost" {
+		t.Fatal("Failed to parse hostname.")
+	}
+
+	if u.Database != "jedis" {
+		t.Fatal("Failed to parse database.")
+	}
+
+	if u.Options["sslmode"] != "" {
+		t.Fatal("Failed to parse SSLMode.")
+	}
+
+	// case with port
+	s = "postgres://anakin:skywalker@localhost:1234/jedis"
 	if u, err = ParseURL(s); err != nil {
 		t.Fatal(err)
 	}

--- a/postgresql/connection_test.go
+++ b/postgresql/connection_test.go
@@ -21,9 +21,7 @@
 
 package postgresql
 
-import (
-	"testing"
-)
+import "testing"
 
 func TestConnectionURL(t *testing.T) {
 	c := ConnectionURL{}
@@ -31,6 +29,13 @@ func TestConnectionURL(t *testing.T) {
 	// Default connection string is empty.
 	if c.String() != "" {
 		t.Fatal(`Expecting default connectiong string to be empty, got:`, c.String())
+	}
+
+	// Adding a host with port.
+	c.Host = "localhost:1234"
+
+	if c.String() != "host=localhost port=1234 sslmode=disable" {
+		t.Fatal(`Test failed, got:`, c.String())
 	}
 
 	// Adding a host.
@@ -83,7 +88,7 @@ func TestParseConnectionURL(t *testing.T) {
 	var s string
 	var err error
 
-	s = "postgres://anakin:skywalker@localhost/jedis"
+	s = "postgres://anakin:skywalker@localhost:1234/jedis"
 
 	if u, err = ParseURL(s); err != nil {
 		t.Fatal(err)
@@ -97,7 +102,7 @@ func TestParseConnectionURL(t *testing.T) {
 		t.Fatal("Failed to parse password.")
 	}
 
-	if u.Host != "localhost" {
+	if u.Host != "localhost:1234" {
 		t.Fatal("Failed to parse hostname.")
 	}
 


### PR DESCRIPTION
This PR allows user to pass in a `port` along with the host to uppers connection url parser.