### PR TITLE
db: support for simple pagination and cursor-based pagination

### DIFF
--- a/db.go
+++ b/db.go
@@ -619,11 +619,13 @@ type Result interface {
 	String() string
 
 	// Limit defines the maximum number of results in this set. It only has
-	// effect on `One()`, `All()` and `Next()`.
+	// effect on `One()`, `All()` and `Next()`. A negative limit cancels any
+	// previous limit settings.
 	Limit(int) Result
 
-	// Offset ignores the first *n* results. It only has effect on `One()`, `All()`
-	// and `Next()`.
+	// Offset ignores the first *n* results. It only has effect on `One()`,
+	// `All()` and `Next()`. A negative offset cancels any previous offset
+	// settings.
 	Offset(int) Result
 
 	// OrderBy receives field names that define the order in which elements will be
@@ -692,7 +694,7 @@ type Result interface {
 
 	// Paginate splits the results of the query into pages containing pageSize
 	// items.  When using pagination previous settings for Limit and Offset are
-	// ignored.
+	// ignored. Page numbering starts at 1.
 	//
 	// Use Page() to define the specific page to get results from.
 	//

--- a/db.go
+++ b/db.go
@@ -690,10 +690,24 @@ type Result interface {
 	// using All().
 	All(sliceOfStructs interface{}) error
 
-	Paginate(int) Result
+	// Paginate splits the results of the query into pages containing pageSize
+	// items.  When using pagination previous settings for Limit and Offset are
+	// ignored.
+	//
+	// Use Page() to define the specific page to get results from.
+	//
+	// Example:
+	//
+	// r = q.Paginate(12)
+	Paginate(pageSize uint) Result
 
-	// Page sets the page number.
-	Page(int) Result
+	// Page makes the result set return results only from the page identified by
+	// pageNumber. Page numbering starts from 0.
+	//
+	// Example:
+	//
+	// r = q.Paginate(12).Page(4)
+	Page(pageNumber uint) Result
 
 	// Cursor defines the column that is going to be taken as basis for
 	// cursor-based pagination.
@@ -706,26 +720,30 @@ type Result interface {
 	// You can set "" as cursorColumn to disable cursors.
 	Cursor(cursorColumn string) Result
 
-	// NextPage returns the next page according to the cursor. It expects a
-	// cursorValue, which is the value the cursor column has on the last item of
-	// the current result set.
+	// NextPage returns the next results page according to the cursor. It expects
+	// a cursorValue, which is the value the cursor column had on the last item
+	// of the current result set.
 	//
 	// Example:
 	//
 	// current = current.NextPage(items[len(items)-1].ID)
 	NextPage(cursorValue interface{}) Result
 
-	// PrevPage returns the previous page according to the cursor. It expects a
-	// cursorValue, which is the value the cursor column has on the fist item of
-	// the current result set.
+	// PrevPage returns the previous results page according to the cursor. It
+	// expects a cursorValue, which is the value the cursor column had on the
+	// fist item of the current result set.
 	//
 	// Example:
 	//
 	// current = current.PrevPage(items[0].ID)
 	PrevPage(cursorValue interface{}) Result
 
-	// TotalPages returns the total number of pages in the query.
-	TotalPages() (uint64, error)
+	// TotalPages returns the total number of pages the result could produce.  If
+	// no pagination has been set this value equals 1.
+	TotalPages() (uint, error)
+
+	// TotalEntries returns the total number of entries in the query.
+	TotalEntries() (uint64, error)
 
 	// Close closes the result set and frees all locked resources.
 	Close() error

--- a/db.go
+++ b/db.go
@@ -690,6 +690,43 @@ type Result interface {
 	// using All().
 	All(sliceOfStructs interface{}) error
 
+	Paginate(int) Result
+
+	// Page sets the page number.
+	Page(int) Result
+
+	// Cursor defines the column that is going to be taken as basis for
+	// cursor-based pagination.
+	//
+	// Example:
+	//
+	// a = q.Paginate(10).Cursor("id")
+	// b = q.Paginate(12).Cursor("-id")
+	//
+	// You can set "" as cursorColumn to disable cursors.
+	Cursor(cursorColumn string) Result
+
+	// NextPage returns the next page according to the cursor. It expects a
+	// cursorValue, which is the value the cursor column has on the last item of
+	// the current result set.
+	//
+	// Example:
+	//
+	// current = current.NextPage(items[len(items)-1].ID)
+	NextPage(cursorValue interface{}) Result
+
+	// PrevPage returns the previous page according to the cursor. It expects a
+	// cursorValue, which is the value the cursor column has on the fist item of
+	// the current result set.
+	//
+	// Example:
+	//
+	// current = current.PrevPage(items[0].ID)
+	PrevPage(cursorValue interface{}) Result
+
+	// TotalPages returns the total number of pages in the query.
+	TotalPages() (uint64, error)
+
 	// Close closes the result set and frees all locked resources.
 	Close() error
 }

--- a/db.go
+++ b/db.go
@@ -700,7 +700,14 @@ type Result interface {
 	//
 	// Example:
 	//
-	// r = q.Paginate(12)
+	//   r = q.Paginate(12)
+	//
+	// You can provide constraints an order settings when using pagination:
+	//
+	// Example:
+	//
+	//   res := q.Where(conds).OrderBy("-id").Paginate(12)
+	//   err := res.Page(4).All(&items)
 	Paginate(pageSize uint) Result
 
 	// Page makes the result set return results only from the page identified by
@@ -708,7 +715,7 @@ type Result interface {
 	//
 	// Example:
 	//
-	// r = q.Paginate(12).Page(4)
+	//   r = q.Paginate(12).Page(4)
 	Page(pageNumber uint) Result
 
 	// Cursor defines the column that is going to be taken as basis for
@@ -716,28 +723,45 @@ type Result interface {
 	//
 	// Example:
 	//
-	// a = q.Paginate(10).Cursor("id")
-	// b = q.Paginate(12).Cursor("-id")
+	//   a = q.Paginate(10).Cursor("id")
+	//   b = q.Paginate(12).Cursor("-id")
 	//
 	// You can set "" as cursorColumn to disable cursors.
 	Cursor(cursorColumn string) Result
 
 	// NextPage returns the next results page according to the cursor. It expects
 	// a cursorValue, which is the value the cursor column had on the last item
-	// of the current result set.
+	// of the current result set (lower bound).
 	//
 	// Example:
 	//
-	// current = current.NextPage(items[len(items)-1].ID)
+	//   cursor = q.Paginate(12).Cursor("id")
+	//   res = cursor.NextPage(items[len(items)-1].ID)
+	//
+	// Note that NextPage requires a cursor, any column with an absolute order
+	// (given two values one always precedes the other) can be a cursor.
+	//
+	// You can define the pagination order and add constraints to your result:
+	//
+	//	 cursor = q.Where(...).OrderBy("id").Paginate(10).Cursor("id")
+	//   res = cursor.NextPage(lowerBound)
 	NextPage(cursorValue interface{}) Result
 
 	// PrevPage returns the previous results page according to the cursor. It
 	// expects a cursorValue, which is the value the cursor column had on the
-	// fist item of the current result set.
+	// fist item of the current result set (upper bound).
 	//
 	// Example:
 	//
-	// current = current.PrevPage(items[0].ID)
+	//   current = current.PrevPage(items[0].ID)
+	//
+	// Note that PrevPage requires a cursor, any column with an absolute order
+	// (given two values one always precedes the other) can be a cursor.
+	//
+	// You can define the pagination order and add constraints to your result:
+	//
+	//   cursor = q.Where(...).OrderBy("id").Paginate(10).Cursor("id")
+	//   res = cursor.PrevPage(upperBound)
 	PrevPage(cursorValue interface{}) Result
 
 	// TotalPages returns the total number of pages the result could produce.  If

--- a/internal/sqladapter/result.go
+++ b/internal/sqladapter/result.go
@@ -44,9 +44,17 @@ type Result struct {
 
 // result represents a delimited set of items bound by a condition.
 type result struct {
-	table   string
-	limit   int
-	offset  int
+	table  string
+	limit  int
+	offset int
+
+	pageSize   int
+	pageNumber int
+
+	cursorColumn        string
+	nextPageCursorValue interface{}
+	prevPageCursorValue interface{}
+
 	fields  []interface{}
 	columns []interface{}
 	orderBy []interface{}
@@ -130,6 +138,45 @@ func (r *Result) Limit(n int) db.Result {
 	})
 }
 
+func (r *Result) Paginate(pageSize int) db.Result {
+	return r.frame(func(res *result) error {
+		res.pageSize = pageSize
+		return nil
+	})
+}
+
+func (r *Result) Page(pageNumber int) db.Result {
+	return r.frame(func(res *result) error {
+		res.pageNumber = pageNumber
+		res.nextPageCursorValue = nil
+		res.prevPageCursorValue = nil
+		return nil
+	})
+}
+
+func (r *Result) Cursor(cursorColumn string) db.Result {
+	return r.frame(func(res *result) error {
+		res.cursorColumn = cursorColumn
+		return nil
+	})
+}
+
+func (r *Result) NextPage(cursorValue interface{}) db.Result {
+	return r.frame(func(res *result) error {
+		res.nextPageCursorValue = cursorValue
+		res.prevPageCursorValue = nil
+		return nil
+	})
+}
+
+func (r *Result) PrevPage(cursorValue interface{}) db.Result {
+	return r.frame(func(res *result) error {
+		res.nextPageCursorValue = nil
+		res.prevPageCursorValue = cursorValue
+		return nil
+	})
+}
+
 // Offset determines how many documents will be skipped before starting to grab
 // Results.
 func (r *Result) Offset(n int) db.Result {
@@ -168,7 +215,7 @@ func (r *Result) Select(fields ...interface{}) db.Result {
 
 // String satisfies fmt.Stringer
 func (r *Result) String() string {
-	query, err := r.buildSelect()
+	query, err := r.buildPaginator()
 	if err != nil {
 		panic(err.Error())
 	}
@@ -177,7 +224,7 @@ func (r *Result) String() string {
 
 // All dumps all Results into a pointer to an slice of structs or maps.
 func (r *Result) All(dst interface{}) error {
-	query, err := r.buildSelect()
+	query, err := r.buildPaginator()
 	if err != nil {
 		return r.setErr(err)
 	}
@@ -187,7 +234,7 @@ func (r *Result) All(dst interface{}) error {
 
 // One fetches only one Result from the set.
 func (r *Result) One(dst interface{}) error {
-	query, err := r.buildSelect()
+	query, err := r.buildPaginator()
 	if err != nil {
 		return r.setErr(err)
 	}
@@ -201,7 +248,7 @@ func (r *Result) Next(dst interface{}) bool {
 	defer r.iterMu.Unlock()
 
 	if r.iter == nil {
-		query, err := r.buildSelect()
+		query, err := r.buildPaginator()
 		if err != nil {
 			r.setErr(err)
 			return false
@@ -251,6 +298,15 @@ func (r *Result) Update(values interface{}) error {
 	return r.setErr(err)
 }
 
+func (r *Result) TotalPages() (uint64, error) {
+	query, err := r.buildPaginator()
+	if err != nil {
+		return 0, r.setErr(err)
+	}
+
+	return query.TotalPages()
+}
+
 // Count counts the elements on the set.
 func (r *Result) Count() (uint64, error) {
 	query, err := r.buildCount()
@@ -261,7 +317,7 @@ func (r *Result) Count() (uint64, error) {
 	counter := struct {
 		Count uint64 `db:"_t"`
 	}{}
-	if err := query.Iterator().One(&counter); err != nil {
+	if err := query.One(&counter); err != nil {
 		if err == db.ErrNoMoreRows {
 			return 0, nil
 		}
@@ -271,7 +327,7 @@ func (r *Result) Count() (uint64, error) {
 	return counter.Count, nil
 }
 
-func (r *Result) buildSelect() (sqlbuilder.Selector, error) {
+func (r *Result) buildPaginator() (sqlbuilder.Paginator, error) {
 	if err := r.Err(); err != nil {
 		return nil, err
 	}
@@ -292,7 +348,19 @@ func (r *Result) buildSelect() (sqlbuilder.Selector, error) {
 		sel = sel.And(filter(res.conds[i])...)
 	}
 
-	return sel, nil
+	pag := sel.Paginate(res.pageSize).
+		Page(res.pageNumber).
+		Cursor(res.cursorColumn)
+
+	if res.nextPageCursorValue != nil {
+		pag = pag.NextPage(res.nextPageCursorValue)
+	}
+
+	if res.prevPageCursorValue != nil {
+		pag = pag.PrevPage(res.prevPageCursorValue)
+	}
+
+	return pag, nil
 }
 
 func (r *Result) buildDelete() (sqlbuilder.Deleter, error) {

--- a/internal/sqladapter/result.go
+++ b/internal/sqladapter/result.go
@@ -48,8 +48,8 @@ type result struct {
 	limit  int
 	offset int
 
-	pageSize   int
-	pageNumber int
+	pageSize   uint
+	pageNumber uint
 
 	cursorColumn        string
 	nextPageCursorValue interface{}
@@ -138,14 +138,14 @@ func (r *Result) Limit(n int) db.Result {
 	})
 }
 
-func (r *Result) Paginate(pageSize int) db.Result {
+func (r *Result) Paginate(pageSize uint) db.Result {
 	return r.frame(func(res *result) error {
 		res.pageSize = pageSize
 		return nil
 	})
 }
 
-func (r *Result) Page(pageNumber int) db.Result {
+func (r *Result) Page(pageNumber uint) db.Result {
 	return r.frame(func(res *result) error {
 		res.pageNumber = pageNumber
 		res.nextPageCursorValue = nil
@@ -298,13 +298,32 @@ func (r *Result) Update(values interface{}) error {
 	return r.setErr(err)
 }
 
-func (r *Result) TotalPages() (uint64, error) {
+func (r *Result) TotalPages() (uint, error) {
 	query, err := r.buildPaginator()
 	if err != nil {
 		return 0, r.setErr(err)
 	}
 
-	return query.TotalPages()
+	total, err := query.TotalPages()
+	if err != nil {
+		return 0, r.setErr(err)
+	}
+
+	return total, nil
+}
+
+func (r *Result) TotalEntries() (uint64, error) {
+	query, err := r.buildPaginator()
+	if err != nil {
+		return 0, r.setErr(err)
+	}
+
+	total, err := query.TotalEntries()
+	if err != nil {
+		return 0, r.setErr(err)
+	}
+
+	return total, nil
 }
 
 // Count counts the elements on the set.

--- a/internal/sqladapter/testing/adapter.go.tpl
+++ b/internal/sqladapter/testing/adapter.go.tpl
@@ -1535,12 +1535,12 @@ func TestPaginator(t *testing.T) {
 	tp, err := paginator.TotalPages()
 	assert.NoError(t, err)
 	assert.NotZero(t, tp)
-	assert.Equal(t, uint64(77), tp)
+	assert.Equal(t, uint(77), tp)
 
-	ti, err := paginator.TotalItems()
+	ti, err := paginator.TotalEntries()
 	assert.NoError(t, err)
 	assert.NotZero(t, ti)
-	assert.Equal(t, 999, ti)
+	assert.Equal(t, uint64(999), ti)
 
 	var seventySixthPage []artistType
 	err = paginator.Page(76).All(&seventySixthPage)
@@ -1557,8 +1557,8 @@ func TestPaginator(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(hundredthPage))
 
-	for i := uint64(0); i < 1; i++ {
-		current := paginator.Page(int(i))
+	for i := uint(0); i < 1; i++ {
+		current := paginator.Page(i)
 
 		var items []artistType
 		err := current.All(&items)
@@ -1627,7 +1627,7 @@ func TestPaginator(t *testing.T) {
 		resultPaginator := result.Paginate(15)
 
 		count, err := resultPaginator.TotalPages()
-		assert.Equal(t, uint64(67), count)
+		assert.Equal(t, uint(67), count)
 		assert.NoError(t, err)
 
 		var items []artistType

--- a/lib/sqlbuilder/builder.go
+++ b/lib/sqlbuilder/builder.go
@@ -387,6 +387,9 @@ func columnFragments(columns []interface{}) ([]exql.Fragment, []interface{}, err
 				return nil, nil, err
 			}
 			q, a := Preprocess(c, v.Arguments())
+			if _, ok := v.(Selector); ok {
+				q = "(" + q + ")"
+			}
 			f[i] = exql.RawValue(q)
 			args = append(args, a...)
 		case db.Function:

--- a/lib/sqlbuilder/builder_test.go
+++ b/lib/sqlbuilder/builder_test.go
@@ -341,8 +341,13 @@ func TestSelect(t *testing.T) {
 	)
 
 	assert.Equal(
-		`SELECT * FROM "artist" LIMIT -1 OFFSET 5`,
+		`SELECT * FROM "artist" OFFSET 5`,
 		b.Select().From("artist").Limit(-1).Offset(5).String(),
+	)
+
+	assert.Equal(
+		`SELECT * FROM "artist" LIMIT 1 OFFSET 5`,
+		b.Select().From("artist").Limit(1).Offset(5).String(),
 	)
 
 	assert.Equal(

--- a/lib/sqlbuilder/interfaces.go
+++ b/lib/sqlbuilder/interfaces.go
@@ -345,7 +345,7 @@ type Selector interface {
 
 	// Paginate returns a paginator that can display a paginated lists of items.
 	// Paginators ignore previous Offset and Limit settings.
-	Paginate(int) Paginator
+	Paginate(uint) Paginator
 
 	// Iterator provides methods to iterate over the results returned by the
 	// Selector.
@@ -538,10 +538,11 @@ type Getter interface {
 	QueryRowContext(ctx context.Context) (*sql.Row, error)
 }
 
-// Paginator provides tools for splitting query results into pages.
+// Paginator provides tools for splitting the results of a query into chunks
+// containing a fixed number of items.
 type Paginator interface {
 	// Page sets the page number.
-	Page(int) Paginator
+	Page(uint) Paginator
 
 	// Cursor defines the column that is going to be taken as basis for
 	// cursor-based pagination.
@@ -573,10 +574,10 @@ type Paginator interface {
 	PrevPage(cursorValue interface{}) Paginator
 
 	// TotalPages returns the total number of pages in the query.
-	TotalPages() (uint64, error)
+	TotalPages() (uint, error)
 
-	// TotalItems returns the total number of items in the query.
-	TotalItems() (int, error)
+	// TotalEntries returns the total number of entries in the query.
+	TotalEntries() (uint64, error)
 
 	// Preparer provides methods for creating prepared statements.
 	Preparer

--- a/lib/sqlbuilder/interfaces.go
+++ b/lib/sqlbuilder/interfaces.go
@@ -328,7 +328,8 @@ type Selector interface {
 
 	// Limit represents the LIMIT parameter.
 	//
-	// LIMIT defines the maximum number of rows to return from the table.
+	// LIMIT defines the maximum number of rows to return from the table.  A
+	// negative limit cancels any previous limit settings.
 	//
 	//  s.Limit(42)
 	Limit(int) Selector
@@ -336,7 +337,9 @@ type Selector interface {
 	// Offset represents the OFFSET parameter.
 	//
 	// OFFSET defines how many results are going to be skipped before starting to
-	// return results.
+	// return results. A negative offset cancels any previous offset settings.
+	//
+	// s.Offset(56)
 	Offset(int) Selector
 
 	// Amend lets you alter the query's text just before sending it to the
@@ -344,7 +347,8 @@ type Selector interface {
 	Amend(func(queryIn string) (queryOut string)) Selector
 
 	// Paginate returns a paginator that can display a paginated lists of items.
-	// Paginators ignore previous Offset and Limit settings.
+	// Paginators ignore previous Offset and Limit settings. Page numbering
+	// starts at 1.
 	Paginate(uint) Paginator
 
 	// Iterator provides methods to iterate over the results returned by the

--- a/lib/sqlbuilder/interfaces.go
+++ b/lib/sqlbuilder/interfaces.go
@@ -345,7 +345,7 @@ type Selector interface {
 
 	// Paginate returns a paginator that can display a paginated lists of items.
 	// Paginators ignore previous Offset and Limit settings.
-	Paginate(uint) Paginator
+	Paginate(int) Paginator
 
 	// Iterator provides methods to iterate over the results returned by the
 	// Selector.
@@ -541,7 +541,7 @@ type Getter interface {
 // Paginator provides tools for splitting query results into pages.
 type Paginator interface {
 	// Page sets the page number.
-	Page(uint) Paginator
+	Page(int) Paginator
 
 	// Cursor defines the column that is going to be taken as basis for
 	// cursor-based pagination.
@@ -573,10 +573,10 @@ type Paginator interface {
 	PrevPage(cursorValue interface{}) Paginator
 
 	// TotalPages returns the total number of pages in the query.
-	TotalPages() (uint, error)
+	TotalPages() (uint64, error)
 
 	// TotalItems returns the total number of items in the query.
-	TotalItems() (uint, error)
+	TotalItems() (int, error)
 
 	// Preparer provides methods for creating prepared statements.
 	Preparer

--- a/lib/sqlbuilder/interfaces.go
+++ b/lib/sqlbuilder/interfaces.go
@@ -553,28 +553,28 @@ type Paginator interface {
 	//
 	// Example:
 	//
-	// a = q.Paginate(10).Cursor("id")
-	// b = q.Paginate(12).Cursor("-id")
+	//   a = q.Paginate(10).Cursor("id")
+	//	 b = q.Paginate(12).Cursor("-id")
 	//
 	// You can set "" as cursorColumn to disable cursors.
 	Cursor(cursorColumn string) Paginator
 
 	// NextPage returns the next page according to the cursor. It expects a
 	// cursorValue, which is the value the cursor column has on the last item of
-	// the current result set.
+	// the current result set (lower bound).
 	//
 	// Example:
 	//
-	// current = current.NextPage(items[len(items)-1].ID)
+	//   p = q.NextPage(items[len(items)-1].ID)
 	NextPage(cursorValue interface{}) Paginator
 
 	// PrevPage returns the previous page according to the cursor. It expects a
 	// cursorValue, which is the value the cursor column has on the fist item of
-	// the current result set.
+	// the current result set (upper bound).
 	//
 	// Example:
 	//
-	// current = current.PrevPage(items[0].ID)
+	//   p = q.PrevPage(items[0].ID)
 	PrevPage(cursorValue interface{}) Paginator
 
 	// TotalPages returns the total number of pages in the query.

--- a/lib/sqlbuilder/paginate.go
+++ b/lib/sqlbuilder/paginate.go
@@ -43,7 +43,7 @@ func newPaginator(sel Selector, pageSize uint) Paginator {
 
 func (pq *paginatorQuery) count() (uint, error) {
 	var count int
-	row, err := pq.sel.(*selector).setColumns(db.Raw("count(1)")).QueryRow()
+	row, err := pq.sel.(*selector).setColumns(db.Raw("count(1) AS _t")).Limit(0).Offset(0).QueryRow()
 
 	err = row.Scan(&count)
 	if err != nil {

--- a/lib/sqlbuilder/paginate.go
+++ b/lib/sqlbuilder/paginate.go
@@ -272,8 +272,6 @@ func (pag *paginator) buildWithCursor() (*paginatorQuery, error) {
 		if pqq.pageNumber > 1 {
 			pqq.sel = pqq.sel.Offset(int(pqq.pageSize * (pqq.pageNumber - 1)))
 		}
-	} else {
-		pqq.sel = pqq.sel.Limit(-1).Offset(0)
 	}
 
 	if pqq.cursorCond != nil {

--- a/lib/sqlbuilder/paginate.go
+++ b/lib/sqlbuilder/paginate.go
@@ -1,0 +1,297 @@
+package sqlbuilder
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"math"
+	"reflect"
+	"strings"
+
+	"upper.io/db.v3"
+	"upper.io/db.v3/internal/immutable"
+)
+
+var (
+	errZeroPageSize        = errors.New("Illegal page size (cannot be zero)")
+	errMissingCursorColumn = errors.New("Missing cursor column")
+)
+
+type paginatorQuery struct {
+	sel Selector
+
+	cursorColumn       string
+	cursorValue        interface{}
+	cursorCond         db.Cond
+	cursorReverseOrder bool
+
+	pageSize   uint
+	pageNumber uint
+}
+
+func newPaginator(sel Selector, pageSize uint) Paginator {
+	pag := &paginator{}
+	return pag.frame(func(pq *paginatorQuery) error {
+		if pageSize < 1 {
+			return errZeroPageSize
+		}
+		pq.pageSize = pageSize
+		pq.sel = sel.Limit(int(pq.pageSize))
+		return nil
+	}).Page(0)
+}
+
+func (pq *paginatorQuery) count() (uint, error) {
+	var count int
+	row, err := pq.sel.(*selector).setColumns(db.Raw("count(1)")).QueryRow()
+
+	err = row.Scan(&count)
+	if err != nil {
+		return 0, err
+	}
+
+	return uint(count), nil
+}
+
+type paginator struct {
+	fn   func(*paginatorQuery) error
+	prev *paginator
+}
+
+var _ = immutable.Immutable(&paginator{})
+
+func (pag *paginator) frame(fn func(*paginatorQuery) error) *paginator {
+	return &paginator{prev: pag, fn: fn}
+}
+
+func (pag *paginator) Page(pageNumber uint) Paginator {
+	return pag.frame(func(pq *paginatorQuery) error {
+		pq.pageNumber = pageNumber
+		pq.sel = pq.sel.Offset(int(pq.pageSize * pq.pageNumber))
+		return nil
+	})
+}
+
+func (pag *paginator) Cursor(column string) Paginator {
+	return pag.frame(func(pq *paginatorQuery) error {
+		pq.cursorColumn = column
+		pq.cursorValue = nil
+		return nil
+	})
+}
+
+func (pag *paginator) NextPage(cursorValue interface{}) Paginator {
+	return pag.frame(func(pq *paginatorQuery) error {
+		if pq.cursorValue != nil && pq.cursorColumn == "" {
+			return errMissingCursorColumn
+		}
+		pq.cursorValue = cursorValue
+		pq.cursorReverseOrder = false
+		pq.cursorCond = db.Cond{
+			pq.cursorColumn + " >": cursorValue,
+		}
+		return nil
+	})
+}
+
+func (pag *paginator) PrevPage(cursorValue interface{}) Paginator {
+	return pag.frame(func(pq *paginatorQuery) error {
+		if pq.cursorValue != nil && pq.cursorColumn == "" {
+			return errMissingCursorColumn
+		}
+		pq.cursorValue = cursorValue
+		pq.cursorReverseOrder = true
+		pq.cursorCond = db.Cond{
+			pq.cursorColumn + " <": cursorValue,
+		}
+		return nil
+	})
+}
+
+func (pag *paginator) TotalPages() (uint, error) {
+	pq, err := pag.build()
+	if err != nil {
+		return 0, err
+	}
+
+	count, err := pq.count()
+	if err != nil {
+		return 0, err
+	}
+
+	if pq.pageSize == 0 {
+		return 0, errZeroPageSize
+	}
+
+	pages := uint(math.Ceil(float64(count) / float64(pq.pageSize)))
+
+	return pages, nil
+}
+
+func (pag *paginator) All(dest interface{}) error {
+	pq, err := pag.buildWithCursor()
+	if err != nil {
+		return err
+	}
+	err = pq.sel.All(dest)
+	if err != nil {
+		return err
+	}
+	if pq.cursorReverseOrder {
+		val := reflect.ValueOf(dest)
+		size := val.Elem().Len()
+		swap := reflect.Swapper(val.Elem().Interface())
+		for i, j := 0, size-1; i < j; i, j = i+1, j-1 {
+			swap(i, j)
+		}
+	}
+	return nil
+}
+
+func (pag *paginator) One(dest interface{}) error {
+	pq, err := pag.buildWithCursor()
+	if err != nil {
+		return err
+	}
+	return pq.sel.One(dest)
+}
+
+func (pag *paginator) Iterator() Iterator {
+	pq, err := pag.buildWithCursor()
+	if err != nil {
+		return &iterator{nil, err}
+	}
+	return pq.sel.Iterator()
+}
+
+func (pag *paginator) IteratorContext(ctx context.Context) Iterator {
+	pq, err := pag.buildWithCursor()
+	if err != nil {
+		return &iterator{nil, err}
+	}
+	return pq.sel.IteratorContext(ctx)
+}
+
+func (pag *paginator) String() string {
+	pq, err := pag.buildWithCursor()
+	if err != nil {
+		panic(err.Error())
+	}
+	return pq.sel.String()
+}
+
+func (pag *paginator) Arguments() []interface{} {
+	pq, err := pag.buildWithCursor()
+	if err != nil {
+		return nil
+	}
+	return pq.sel.Arguments()
+}
+
+func (pag *paginator) Query() (*sql.Rows, error) {
+	pq, err := pag.buildWithCursor()
+	if err != nil {
+		return nil, err
+	}
+	return pq.sel.Query()
+}
+
+func (pag *paginator) QueryContext(ctx context.Context) (*sql.Rows, error) {
+	pq, err := pag.buildWithCursor()
+	if err != nil {
+		return nil, err
+	}
+	return pq.sel.QueryContext(ctx)
+}
+
+func (pag *paginator) QueryRow() (*sql.Row, error) {
+	pq, err := pag.buildWithCursor()
+	if err != nil {
+		return nil, err
+	}
+	return pq.sel.QueryRow()
+}
+
+func (pag *paginator) QueryRowContext(ctx context.Context) (*sql.Row, error) {
+	pq, err := pag.buildWithCursor()
+	if err != nil {
+		return nil, err
+	}
+	return pq.sel.QueryRowContext(ctx)
+}
+
+func (pag *paginator) Prepare() (*sql.Stmt, error) {
+	pq, err := pag.buildWithCursor()
+	if err != nil {
+		return nil, err
+	}
+	return pq.sel.Prepare()
+}
+
+func (pag *paginator) PrepareContext(ctx context.Context) (*sql.Stmt, error) {
+	pq, err := pag.buildWithCursor()
+	if err != nil {
+		return nil, err
+	}
+	return pq.sel.PrepareContext(ctx)
+}
+
+func (pag *paginator) TotalItems() (uint, error) {
+	pq, err := pag.build()
+	if err != nil {
+		return 0, err
+	}
+	return pq.count()
+}
+
+func (pag *paginator) build() (*paginatorQuery, error) {
+	pq, err := immutable.FastForward(pag)
+	if err != nil {
+		return nil, err
+	}
+	return pq.(*paginatorQuery), nil
+}
+
+func (pag *paginator) buildWithCursor() (*paginatorQuery, error) {
+	pq, err := immutable.FastForward(pag)
+	if err != nil {
+		return nil, err
+	}
+
+	pqq := pq.(*paginatorQuery)
+	if pqq.cursorColumn != "" {
+		orderBy := pqq.cursorColumn
+		if pqq.cursorReverseOrder {
+			if strings.HasPrefix(orderBy, "-") {
+				orderBy = orderBy[1:]
+			} else {
+				orderBy = "-" + orderBy
+			}
+		}
+		pqq.sel = pqq.sel.OrderBy(orderBy)
+	}
+
+	if pqq.cursorCond != nil {
+		pqq.sel = pqq.sel.Where(pqq.cursorCond).Offset(0)
+	}
+
+	return pqq, nil
+}
+
+func (pag *paginator) Prev() immutable.Immutable {
+	if pag == nil {
+		return nil
+	}
+	return pag.prev
+}
+
+func (pag *paginator) Fn(in interface{}) error {
+	if pag.fn == nil {
+		return nil
+	}
+	return pag.fn(in.(*paginatorQuery))
+}
+
+func (pag *paginator) Base() interface{} {
+	return &paginatorQuery{}
+}

--- a/lib/sqlbuilder/select.go
+++ b/lib/sqlbuilder/select.go
@@ -411,7 +411,7 @@ func (sel *selector) As(alias string) Selector {
 			if err != nil {
 				return err
 			}
-			sq.table.Columns[last] = exql.RawValue("(" + raw.Value + ") AS " + compiled)
+			sq.table.Columns[last] = exql.RawValue(raw.Value + " AS " + compiled)
 		}
 		return nil
 	})

--- a/lib/sqlbuilder/select.go
+++ b/lib/sqlbuilder/select.go
@@ -193,6 +193,10 @@ func (sel *selector) Distinct(exps ...interface{}) Selector {
 
 func (sel *selector) Where(terms ...interface{}) Selector {
 	return sel.frame(func(sq *selectorQuery) error {
+		if len(terms) == 1 && terms[0] == nil {
+			sq.where, sq.whereArgs = &exql.Where{}, []interface{}{}
+			return nil
+		}
 		return sq.and(sel.SQLBuilder(), terms...)
 	})
 }
@@ -374,6 +378,9 @@ func (sel *selector) On(terms ...interface{}) Selector {
 
 func (sel *selector) Limit(n int) Selector {
 	return sel.frame(func(sq *selectorQuery) error {
+		if n < 0 {
+			n = 0
+		}
 		sq.limit = exql.Limit(n)
 		return nil
 	})
@@ -381,6 +388,9 @@ func (sel *selector) Limit(n int) Selector {
 
 func (sel *selector) Offset(n int) Selector {
 	return sel.frame(func(sq *selectorQuery) error {
+		if n < 0 {
+			n = 0
+		}
 		sq.offset = exql.Offset(n)
 		return nil
 	})
@@ -463,7 +473,7 @@ func (sel *selector) IteratorContext(ctx context.Context) Iterator {
 	return &iterator{rows, err}
 }
 
-func (sel *selector) Paginate(pageSize uint) Paginator {
+func (sel *selector) Paginate(pageSize int) Paginator {
 	return newPaginator(sel.clone(), pageSize)
 }
 

--- a/lib/sqlbuilder/select.go
+++ b/lib/sqlbuilder/select.go
@@ -474,7 +474,7 @@ func (sel *selector) IteratorContext(ctx context.Context) Iterator {
 	return &iterator{rows, err}
 }
 
-func (sel *selector) Paginate(pageSize int) Paginator {
+func (sel *selector) Paginate(pageSize uint) Paginator {
 	return newPaginator(sel.clone(), pageSize)
 }
 

--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -172,7 +172,7 @@ func (col *Collection) compileQuery(terms ...interface{}) interface{} {
 			query = mapped
 		}
 	} else {
-		query = map[string]interface{}{}
+		query = nil
 	}
 
 	return query

--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -40,15 +40,6 @@ type Collection struct {
 	collection *mgo.Collection
 }
 
-type chunks struct {
-	Fields     []string
-	Limit      int
-	Offset     int
-	Sort       []string
-	Conditions interface{}
-	GroupBy    []interface{}
-}
-
 var (
 	// idCache should be a struct if we're going to cache more than just
 	// _id field here
@@ -58,22 +49,19 @@ var (
 
 // Find creates a result set with the given conditions.
 func (col *Collection) Find(terms ...interface{}) db.Result {
-	queryChunks := &chunks{}
+	fields := []string{"*"}
 
-	// No specific fields given.
-	if len(queryChunks.Fields) == 0 {
-		queryChunks.Fields = []string{"*"}
-	}
+	conditions := col.compileQuery(terms...)
 
-	queryChunks.Conditions = col.compileQuery(terms...)
+	res := &result{}
+	res = res.frame(func(r *resultQuery) error {
+		r.c = col
+		r.conditions = conditions
+		r.fields = fields
+		return nil
+	})
 
-	// Actually executing query.
-	r := &result{
-		c:           col,
-		queryChunks: queryChunks,
-	}
-
-	return r
+	return res
 }
 
 // compileStatement transforms conditions into something *mgo.Session can

--- a/mongo/database_test.go
+++ b/mongo/database_test.go
@@ -886,9 +886,7 @@ func TestPaginator(t *testing.T) {
 			assert.NoError(t, err)
 
 			if len(items) < 1 {
-				if i > 0 {
-					t.Fatal("Expecting more pages")
-				}
+				assert.Equal(t, 0, len(items))
 				break
 			}
 			for j := 0; j < len(items); j++ {

--- a/mongo/database_test.go
+++ b/mongo/database_test.go
@@ -882,12 +882,13 @@ func TestPaginator(t *testing.T) {
 		for i := 76; ; i-- {
 			var items []artistType
 
-			log.Printf("Fetch all")
 			err := current.All(&items)
 			assert.NoError(t, err)
 
-			log.Printf("ITEMS: %v", items)
 			if len(items) < 1 {
+				if i > 0 {
+					t.Fatal("Expecting more pages")
+				}
 				break
 			}
 			for j := 0; j < len(items); j++ {

--- a/mongo/database_test.go
+++ b/mongo/database_test.go
@@ -818,9 +818,9 @@ func TestPaginator(t *testing.T) {
 	tp, err := paginator.TotalPages()
 	assert.NoError(t, err)
 	assert.NotZero(t, tp)
-	assert.Equal(t, uint64(77), tp)
+	assert.Equal(t, uint(77), tp)
 
-	ti, err := paginator.Count()
+	ti, err := paginator.TotalEntries()
 	assert.NoError(t, err)
 	assert.NotZero(t, ti)
 	assert.Equal(t, uint64(999), ti)
@@ -840,8 +840,8 @@ func TestPaginator(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(hundredthPage))
 
-	for i := uint64(0); i < tp; i++ {
-		current := paginator.Page(int(i))
+	for i := uint(0); i < tp; i++ {
+		current := paginator.Page(i)
 
 		var items []artistType
 		err := current.All(&items)
@@ -901,7 +901,7 @@ func TestPaginator(t *testing.T) {
 		resultPaginator := sess.Collection("artist").Find().Paginate(15)
 
 		count, err := resultPaginator.TotalPages()
-		assert.Equal(t, uint64(67), count)
+		assert.Equal(t, uint(67), count)
 		assert.NoError(t, err)
 
 		var items []artistType

--- a/mongo/database_test.go
+++ b/mongo/database_test.go
@@ -23,6 +23,8 @@
 package mongo
 
 import (
+	"fmt"
+	"log"
 	"math/rand"
 	"os"
 	"reflect"
@@ -30,6 +32,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"gopkg.in/mgo.v2/bson"
 	"upper.io/db.v3"
 )
@@ -770,5 +773,178 @@ func TestDataTypes(t *testing.T) {
 	// The original value and the test subject must match.
 	if reflect.DeepEqual(item, testValues) == false {
 		t.Errorf("Struct is different.")
+	}
+}
+
+func TestPaginator(t *testing.T) {
+	type artistType struct {
+		ID   bson.ObjectId `bson:"_id,omitempty"`
+		Name string        `bson:"name"`
+	}
+
+	// Opening database.
+	sess, err := Open(settings)
+	assert.NoError(t, err)
+
+	// We should close the database when it's no longer in use.
+	defer sess.Close()
+
+	// Getting a pointer to the "artist" collection.
+	artist := sess.Collection("artist")
+
+	err = artist.Truncate()
+	assert.NoError(t, err)
+
+	for i := 0; i < 999; i++ {
+		_, err = artist.Insert(artistType{
+			Name: fmt.Sprintf("artist-%d", i),
+		})
+		assert.NoError(t, err)
+	}
+
+	q := sess.Collection("artist").Find().Paginate(15)
+	paginator := q.Paginate(13)
+
+	var zerothPage []artistType
+	err = paginator.Page(0).All(&zerothPage)
+	assert.NoError(t, err)
+	assert.Equal(t, 13, len(zerothPage))
+
+	var secondPage []artistType
+	err = paginator.Page(2).All(&secondPage)
+	assert.NoError(t, err)
+	assert.Equal(t, 13, len(secondPage))
+
+	tp, err := paginator.TotalPages()
+	assert.NoError(t, err)
+	assert.NotZero(t, tp)
+	assert.Equal(t, uint64(77), tp)
+
+	ti, err := paginator.Count()
+	assert.NoError(t, err)
+	assert.NotZero(t, ti)
+	assert.Equal(t, uint64(999), ti)
+
+	var seventySixthPage []artistType
+	err = paginator.Page(76).All(&seventySixthPage)
+	assert.NoError(t, err)
+	assert.Equal(t, 11, len(seventySixthPage))
+
+	var seventySeventhPage []artistType
+	err = paginator.Page(77).All(&seventySeventhPage)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(seventySeventhPage))
+
+	var hundredthPage []artistType
+	err = paginator.Page(100).All(&hundredthPage)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(hundredthPage))
+
+	for i := uint64(0); i < tp; i++ {
+		current := paginator.Page(int(i))
+
+		var items []artistType
+		err := current.All(&items)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(items) < 1 {
+			break
+		}
+		for j := 0; j < len(items); j++ {
+			assert.Equal(t, fmt.Sprintf("artist-%d", int64(13*int(i)+j)), items[j].Name)
+		}
+	}
+
+	paginator = paginator.Cursor("_id")
+	{
+		current := paginator.Page(0)
+		for i := 0; ; i++ {
+			var items []artistType
+			err := current.All(&items)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(items) < 1 {
+				break
+			}
+
+			for j := 0; j < len(items); j++ {
+				assert.Equal(t, fmt.Sprintf("artist-%d", int64(13*int(i)+j)), items[j].Name)
+			}
+			current = current.NextPage(items[len(items)-1].ID)
+		}
+	}
+
+	{
+		log.Printf("Page 76")
+		current := paginator.Page(76)
+		for i := 76; ; i-- {
+			var items []artistType
+
+			log.Printf("Fetch all")
+			err := current.All(&items)
+			assert.NoError(t, err)
+
+			log.Printf("ITEMS: %v", items)
+			if len(items) < 1 {
+				break
+			}
+			for j := 0; j < len(items); j++ {
+				assert.Equal(t, fmt.Sprintf("artist-%d", 13*int(i)+j), items[j].Name)
+			}
+
+			current = current.PrevPage(items[0].ID)
+		}
+	}
+
+	{
+		resultPaginator := sess.Collection("artist").Find().Paginate(15)
+
+		count, err := resultPaginator.TotalPages()
+		assert.Equal(t, uint64(67), count)
+		assert.NoError(t, err)
+
+		var items []artistType
+		err = resultPaginator.Page(5).All(&items)
+		assert.NoError(t, err)
+
+		for j := 0; j < len(items); j++ {
+			assert.Equal(t, fmt.Sprintf("artist-%d", 15*5+j), items[j].Name)
+		}
+
+		resultPaginator = resultPaginator.Cursor("_id").Page(0)
+		for i := 0; ; i++ {
+			var items []artistType
+
+			err = resultPaginator.All(&items)
+			assert.NoError(t, err)
+
+			if len(items) < 1 {
+				break
+			}
+
+			for j := 0; j < len(items); j++ {
+				assert.Equal(t, fmt.Sprintf("artist-%d", 15*i+j), items[j].Name)
+			}
+			resultPaginator = resultPaginator.NextPage(items[len(items)-1].ID)
+		}
+
+		resultPaginator = resultPaginator.Cursor("_id").Page(66)
+		for i := 66; ; i-- {
+			var items []artistType
+
+			err = resultPaginator.All(&items)
+			assert.NoError(t, err)
+
+			if len(items) < 1 {
+				break
+			}
+
+			for j := 0; j < len(items); j++ {
+				assert.Equal(t, fmt.Sprintf("artist-%d", 15*i+j), items[j].Name)
+			}
+			resultPaginator = resultPaginator.PrevPage(items[0].ID)
+		}
 	}
 }

--- a/mongo/result.go
+++ b/mongo/result.go
@@ -23,7 +23,6 @@ package mongo
 
 import (
 	"fmt"
-	"log"
 	"math"
 	"strings"
 	"sync"
@@ -72,8 +71,6 @@ func (res *result) frame(fn func(*resultQuery) error) *result {
 }
 
 func (r *resultQuery) and(terms ...interface{}) error {
-	log.Printf("AND: %#v -- %v -- %T", r.conditions, terms, terms)
-
 	if r.conditions == nil {
 		return r.where(terms...)
 	}
@@ -420,8 +417,6 @@ func (res *result) build() (*resultQuery, error) {
 			rq.sort = append(rq.sort, rq.cursorColumn)
 		}
 	}
-	log.Printf("QUERY: %#v", rq)
-
 	return rq, nil
 }
 
@@ -474,8 +469,6 @@ func (r *resultQuery) query() (*mgo.Query, error) {
 		r.conditions = bson.M{"_id": bson.M{"$in": ids}}
 
 		q = r.c.collection.Find(r.conditions)
-
-		log.Printf("IDS: %#v", ids)
 	}
 
 	if len(selectedFields) > 0 {

--- a/mongo/result.go
+++ b/mongo/result.go
@@ -47,8 +47,8 @@ type resultQuery struct {
 	conditions interface{}
 	groupBy    []interface{}
 
-	pageSize           int
-	pageNumber         int
+	pageSize           uint
+	pageNumber         uint
 	cursorColumn       string
 	cursorValue        interface{}
 	cursorCond         db.Cond
@@ -101,14 +101,14 @@ func (res *result) Where(terms ...interface{}) db.Result {
 	})
 }
 
-func (res *result) Paginate(pageSize int) db.Result {
+func (res *result) Paginate(pageSize uint) db.Result {
 	return res.frame(func(r *resultQuery) error {
 		r.pageSize = pageSize
 		return nil
 	})
 }
 
-func (res *result) Page(pageNumber int) db.Result {
+func (res *result) Page(pageNumber uint) db.Result {
 	return res.frame(func(r *resultQuery) error {
 		r.pageNumber = pageNumber
 		return nil
@@ -144,7 +144,11 @@ func (res *result) PrevPage(cursorValue interface{}) db.Result {
 	})
 }
 
-func (res *result) TotalPages() (uint64, error) {
+func (res *result) TotalEntries() (uint64, error) {
+	return res.Count()
+}
+
+func (res *result) TotalPages() (uint, error) {
 	count, err := res.Count()
 	if err != nil {
 		return 0, err
@@ -159,7 +163,7 @@ func (res *result) TotalPages() (uint64, error) {
 		return 1, nil
 	}
 
-	total := uint64(math.Ceil(float64(count) / float64(rq.pageSize)))
+	total := uint(math.Ceil(float64(count) / float64(rq.pageSize)))
 	return total, nil
 }
 
@@ -429,8 +433,8 @@ func (r *resultQuery) query() (*mgo.Query, error) {
 	q := r.c.collection.Find(r.conditions)
 
 	if r.pageSize > 0 {
-		r.offset = r.pageSize * r.pageNumber
-		r.limit = r.pageSize
+		r.offset = int(r.pageSize * r.pageNumber)
+		r.limit = int(r.pageSize)
 	}
 
 	if r.offset > 0 {

--- a/mssql/template.go
+++ b/mssql/template.go
@@ -85,17 +85,18 @@ const (
 	adapterSelectLayout = `
 		{{if or .Limit .Offset}}
 			SELECT __q0.* FROM (
-				SELECT {{if gt .Limit 0}}TOP ({{.Limit}}{{if gt .Offset 0}} + {{.Offset}}{{end}}){{end}} __q1.*,
+				SELECT TOP 100 PERCENT __q1.*,
 				ROW_NUMBER() OVER (ORDER BY (SELECT 1)) AS rnum FROM
 			(
 		{{end}}
 
 			SELECT
+
 				{{if .Distinct}}
 					DISTINCT
 				{{end}}
 
-				{{if .OrderBy}}TOP 100 PERCENT{{end}}
+				{{if or .Limit .Offset}}TOP ({{if gt .Limit 0}}{{.Limit}}{{else}}0{{end}} + {{if gt .Offset 0}}{{.Offset}}{{else}}0{{end}}){{end}}
 
 				{{if .Columns}}
 					{{.Columns}}

--- a/mssql/template_test.go
+++ b/mssql/template_test.go
@@ -23,27 +23,27 @@ func TestTemplateSelect(t *testing.T) {
 	)
 
 	assert.Equal(
-		"SELECT TOP 100 PERCENT * FROM [artist] ORDER BY [name] DESC",
+		"SELECT * FROM [artist] ORDER BY [name] DESC",
 		b.Select().From("artist").OrderBy("name DESC").String(),
 	)
 
 	assert.Equal(
-		"SELECT TOP 100 PERCENT * FROM [artist] ORDER BY [name] DESC",
+		"SELECT * FROM [artist] ORDER BY [name] DESC",
 		b.Select().From("artist").OrderBy("-name").String(),
 	)
 
 	assert.Equal(
-		"SELECT TOP 100 PERCENT * FROM [artist] ORDER BY [name] ASC",
+		"SELECT * FROM [artist] ORDER BY [name] ASC",
 		b.Select().From("artist").OrderBy("name").String(),
 	)
 
 	assert.Equal(
-		"SELECT TOP 100 PERCENT * FROM [artist] ORDER BY [name] ASC",
+		"SELECT * FROM [artist] ORDER BY [name] ASC",
 		b.Select().From("artist").OrderBy("name ASC").String(),
 	)
 
 	assert.Equal(
-		"SELECT __q0.* FROM ( SELECT __q1.*, ROW_NUMBER() OVER (ORDER BY (SELECT 1)) AS rnum FROM ( SELECT * FROM [artist] ) __q1) __q0 WHERE rnum > 5",
+		"SELECT __q0.* FROM ( SELECT TOP 100 PERCENT __q1.*, ROW_NUMBER() OVER (ORDER BY (SELECT 1)) AS rnum FROM ( SELECT TOP (0 + 5) * FROM [artist] ) __q1) __q0 WHERE rnum > 5",
 		b.Select().From("artist").Limit(-1).Offset(5).String(),
 	)
 
@@ -93,7 +93,7 @@ func TestTemplateSelect(t *testing.T) {
 	)
 
 	assert.Equal(
-		"SELECT __q0.* FROM ( SELECT TOP (1) __q1.*, ROW_NUMBER() OVER (ORDER BY (SELECT 1)) AS rnum FROM ( SELECT * FROM [artist] AS [a], [publication] AS [p] WHERE (p.author_id = a.id) ) __q1) __q0 WHERE rnum > 0",
+		"SELECT __q0.* FROM ( SELECT TOP 100 PERCENT __q1.*, ROW_NUMBER() OVER (ORDER BY (SELECT 1)) AS rnum FROM ( SELECT TOP (1 + 0) * FROM [artist] AS [a], [publication] AS [p] WHERE (p.author_id = a.id) ) __q1) __q0 WHERE rnum > 0",
 		b.Select().From("artist a", "publication as p").Where("p.author_id = a.id").Limit(1).String(),
 	)
 
@@ -103,22 +103,22 @@ func TestTemplateSelect(t *testing.T) {
 	)
 
 	assert.Equal(
-		"SELECT __q0.* FROM ( SELECT TOP (1) __q1.*, ROW_NUMBER() OVER (ORDER BY (SELECT 1)) AS rnum FROM ( SELECT * FROM [artist] AS [a] JOIN [publication] AS [p] ON (p.author_id = a.id) ) __q1) __q0 WHERE rnum > 0",
+		"SELECT __q0.* FROM ( SELECT TOP 100 PERCENT __q1.*, ROW_NUMBER() OVER (ORDER BY (SELECT 1)) AS rnum FROM ( SELECT TOP (1 + 0) * FROM [artist] AS [a] JOIN [publication] AS [p] ON (p.author_id = a.id) ) __q1) __q0 WHERE rnum > 0",
 		b.SelectFrom("artist a").Join("publication p").On("p.author_id = a.id").Limit(1).String(),
 	)
 
 	assert.Equal(
-		"SELECT __q0.* FROM ( SELECT TOP (1) __q1.*, ROW_NUMBER() OVER (ORDER BY (SELECT 1)) AS rnum FROM ( SELECT * FROM [artist] AS [a] JOIN [publication] AS [p] ON (p.author_id = a.id) WHERE ([a].[id] = $1) ) __q1) __q0 WHERE rnum > 0",
+		"SELECT __q0.* FROM ( SELECT TOP 100 PERCENT __q1.*, ROW_NUMBER() OVER (ORDER BY (SELECT 1)) AS rnum FROM ( SELECT TOP (1 + 0) * FROM [artist] AS [a] JOIN [publication] AS [p] ON (p.author_id = a.id) WHERE ([a].[id] = $1) ) __q1) __q0 WHERE rnum > 0",
 		b.SelectFrom("artist a").Join("publication p").On("p.author_id = a.id").Where("a.id", 2).Limit(1).String(),
 	)
 
 	assert.Equal(
-		"SELECT __q0.* FROM ( SELECT TOP (1) __q1.*, ROW_NUMBER() OVER (ORDER BY (SELECT 1)) AS rnum FROM ( SELECT * FROM [artist] JOIN [publication] AS [p] ON (p.author_id = a.id) WHERE (a.id = 2) ) __q1) __q0 WHERE rnum > 0",
+		"SELECT __q0.* FROM ( SELECT TOP 100 PERCENT __q1.*, ROW_NUMBER() OVER (ORDER BY (SELECT 1)) AS rnum FROM ( SELECT TOP (1 + 0) * FROM [artist] JOIN [publication] AS [p] ON (p.author_id = a.id) WHERE (a.id = 2) ) __q1) __q0 WHERE rnum > 0",
 		b.SelectFrom("artist").Join("publication p").On("p.author_id = a.id").Where("a.id = 2").Limit(1).String(),
 	)
 
 	assert.Equal(
-		"SELECT __q0.* FROM ( SELECT TOP (1) __q1.*, ROW_NUMBER() OVER (ORDER BY (SELECT 1)) AS rnum FROM ( SELECT * FROM [artist] AS [a] JOIN [publication] AS [p] ON (p.title LIKE $1 OR p.title LIKE $2) WHERE (a.id = $3) ) __q1) __q0 WHERE rnum > 0",
+		"SELECT __q0.* FROM ( SELECT TOP 100 PERCENT __q1.*, ROW_NUMBER() OVER (ORDER BY (SELECT 1)) AS rnum FROM ( SELECT TOP (1 + 0) * FROM [artist] AS [a] JOIN [publication] AS [p] ON (p.title LIKE $1 OR p.title LIKE $2) WHERE (a.id = $3) ) __q1) __q0 WHERE rnum > 0",
 		b.SelectFrom("artist a").Join("publication p").On("p.title LIKE ? OR p.title LIKE ?", "%Totoro%", "%Robot%").Where("a.id = ?", 2).Limit(1).String(),
 	)
 

--- a/mysql/template_test.go
+++ b/mysql/template_test.go
@@ -43,7 +43,7 @@ func TestTemplateSelect(t *testing.T) {
 	)
 
 	assert.Equal(
-		"SELECT * FROM `artist` LIMIT -1 OFFSET 5",
+		"SELECT * FROM `artist` OFFSET 5",
 		b.Select().From("artist").Limit(-1).Offset(5).String(),
 	)
 

--- a/ql/collection.go
+++ b/ql/collection.go
@@ -69,7 +69,7 @@ func (r *resultProxy) Select(fields ...interface{}) db.Result {
 				Iterator().All(&columns)
 			if err == nil {
 				fields = make([]interface{}, 0, len(columns)+1)
-				fields = append(fields, "id() as id")
+				fields = append(fields, "id() AS id")
 				for _, column := range columns {
 					fields = append(fields, column.Name)
 				}

--- a/ql/database.go
+++ b/ql/database.go
@@ -28,6 +28,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -155,6 +156,9 @@ func (d *database) Collections() (collections []string, err error) {
 		var tableName string
 		if err := iter.Scan(&tableName); err != nil {
 			return nil, err
+		}
+		if strings.HasPrefix(tableName, "__") {
+			continue
 		}
 		collections = append(collections, tableName)
 	}

--- a/ql/template.go
+++ b/ql/template.go
@@ -46,11 +46,7 @@ const (
 	adapterColumnAliasLayout   = `{{.Name}}{{if .Alias}} AS {{.Alias}}{{end}}`
 	adapterSortByColumnLayout  = `{{.Column}} {{.Order}}`
 
-	adapterOrderByLayout = `
-    {{if .SortColumns}}
-      ORDER BY {{.SortColumns}}
-    {{end}}
-  `
+	adapterOrderByLayout = `{{if .SortColumns}}ORDER BY {{.SortColumns}}{{end}}`
 
 	adapterWhereLayout = `
     {{if .Conds}}
@@ -92,7 +88,6 @@ const (
         DISTINCT
       {{end}}
 
-
       {{if .Columns}}
         {{.Columns}}
       {{else}}
@@ -109,7 +104,13 @@ const (
 
       {{.GroupBy}}
 
-      {{.OrderBy}}
+      {{if .OrderBy}}
+				{{.OrderBy}}
+			{{else}}
+				{{if .Table}}
+					ORDER BY id() ASC
+				{{end}}
+			{{end}}
 
       {{if .Limit}}
         LIMIT {{.Limit}}

--- a/ql/template_test.go
+++ b/ql/template_test.go
@@ -13,12 +13,12 @@ func TestTemplateSelect(t *testing.T) {
 	assert := assert.New(t)
 
 	assert.Equal(
-		"SELECT * FROM artist",
+		"SELECT * FROM artist ORDER BY id() ASC",
 		b.SelectFrom("artist").String(),
 	)
 
 	assert.Equal(
-		"SELECT * FROM artist",
+		"SELECT * FROM artist ORDER BY id() ASC",
 		b.Select().From("artist").String(),
 	)
 
@@ -43,87 +43,87 @@ func TestTemplateSelect(t *testing.T) {
 	)
 
 	assert.Equal(
-		"SELECT * FROM artist OFFSET 5",
+		"SELECT * FROM artist ORDER BY id() ASC OFFSET 5",
 		b.Select().From("artist").Limit(-1).Offset(5).String(),
 	)
 
 	assert.Equal(
-		"SELECT id FROM artist",
+		"SELECT id FROM artist ORDER BY id() ASC",
 		b.Select("id").From("artist").String(),
 	)
 
 	assert.Equal(
-		"SELECT id, name FROM artist",
+		"SELECT id, name FROM artist ORDER BY id() ASC",
 		b.Select("id", "name").From("artist").String(),
 	)
 
 	assert.Equal(
-		"SELECT * FROM artist WHERE (name == $1)",
+		"SELECT * FROM artist WHERE (name == $1) ORDER BY id() ASC",
 		b.SelectFrom("artist").Where("name", "Haruki").String(),
 	)
 
 	assert.Equal(
-		"SELECT * FROM artist WHERE (name LIKE $1)",
+		"SELECT * FROM artist WHERE (name LIKE $1) ORDER BY id() ASC",
 		b.SelectFrom("artist").Where("name LIKE ?", `%F%`).String(),
 	)
 
 	assert.Equal(
-		"SELECT id FROM artist WHERE (name LIKE $1 OR name LIKE $2)",
+		"SELECT id FROM artist WHERE (name LIKE $1 OR name LIKE $2) ORDER BY id() ASC",
 		b.Select("id").From("artist").Where(`name LIKE ? OR name LIKE ?`, `%Miya%`, `F%`).String(),
 	)
 
 	assert.Equal(
-		"SELECT * FROM artist WHERE (id > $1)",
+		"SELECT * FROM artist WHERE (id > $1) ORDER BY id() ASC",
 		b.SelectFrom("artist").Where("id >", 2).String(),
 	)
 
 	assert.Equal(
-		"SELECT * FROM artist WHERE (id <= 2 AND name != $1)",
+		"SELECT * FROM artist WHERE (id <= 2 AND name != $1) ORDER BY id() ASC",
 		b.SelectFrom("artist").Where("id <= 2 AND name != ?", "A").String(),
 	)
 
 	assert.Equal(
-		"SELECT * FROM artist WHERE (id IN ($1, $2, $3, $4))",
+		"SELECT * FROM artist WHERE (id IN ($1, $2, $3, $4)) ORDER BY id() ASC",
 		b.SelectFrom("artist").Where("id IN", []int{1, 9, 8, 7}).String(),
 	)
 
 	assert.Equal(
-		"SELECT * FROM artist WHERE (name IS NOT NULL)",
+		"SELECT * FROM artist WHERE (name IS NOT NULL) ORDER BY id() ASC",
 		b.SelectFrom("artist").Where("name IS NOT NULL").String(),
 	)
 
 	assert.Equal(
-		"SELECT * FROM artist AS a, publication AS p WHERE (p.author_id = a.id) LIMIT 1",
+		"SELECT * FROM artist AS a, publication AS p WHERE (p.author_id = a.id) ORDER BY id() ASC LIMIT 1",
 		b.Select().From("artist a", "publication as p").Where("p.author_id = a.id").Limit(1).String(),
 	)
 
 	assert.Equal(
-		"SELECT id FROM artist NATURAL JOIN publication",
+		"SELECT id FROM artist NATURAL JOIN publication ORDER BY id() ASC",
 		b.Select("id").From("artist").Join("publication").String(),
 	)
 
 	assert.Equal(
-		"SELECT * FROM artist AS a JOIN publication AS p ON (p.author_id = a.id) LIMIT 1",
+		"SELECT * FROM artist AS a JOIN publication AS p ON (p.author_id = a.id) ORDER BY id() ASC LIMIT 1",
 		b.SelectFrom("artist a").Join("publication p").On("p.author_id = a.id").Limit(1).String(),
 	)
 
 	assert.Equal(
-		"SELECT * FROM artist AS a JOIN publication AS p ON (p.author_id = a.id) WHERE (a.id == $1) LIMIT 1",
+		"SELECT * FROM artist AS a JOIN publication AS p ON (p.author_id = a.id) WHERE (a.id == $1) ORDER BY id() ASC LIMIT 1",
 		b.SelectFrom("artist a").Join("publication p").On("p.author_id = a.id").Where("a.id", 2).Limit(1).String(),
 	)
 
 	assert.Equal(
-		"SELECT * FROM artist JOIN publication AS p ON (p.author_id = a.id) WHERE (a.id = 2) LIMIT 1",
+		"SELECT * FROM artist JOIN publication AS p ON (p.author_id = a.id) WHERE (a.id = 2) ORDER BY id() ASC LIMIT 1",
 		b.SelectFrom("artist").Join("publication p").On("p.author_id = a.id").Where("a.id = 2").Limit(1).String(),
 	)
 
 	assert.Equal(
-		"SELECT * FROM artist AS a JOIN publication AS p ON (p.title LIKE $1 OR p.title LIKE $2) WHERE (a.id = $3) LIMIT 1",
+		"SELECT * FROM artist AS a JOIN publication AS p ON (p.title LIKE $1 OR p.title LIKE $2) WHERE (a.id = $3) ORDER BY id() ASC LIMIT 1",
 		b.SelectFrom("artist a").Join("publication p").On("p.title LIKE ? OR p.title LIKE ?", "%Totoro%", "%Robot%").Where("a.id = ?", 2).Limit(1).String(),
 	)
 
 	assert.Equal(
-		"SELECT * FROM artist AS a LEFT JOIN publication AS p1 ON (p1.id = a.id) RIGHT JOIN publication AS p2 ON (p2.id = a.id)",
+		"SELECT * FROM artist AS a LEFT JOIN publication AS p1 ON (p1.id = a.id) RIGHT JOIN publication AS p2 ON (p2.id = a.id) ORDER BY id() ASC",
 		b.SelectFrom("artist a").
 			LeftJoin("publication p1").On("p1.id = a.id").
 			RightJoin("publication p2").On("p2.id = a.id").
@@ -131,12 +131,12 @@ func TestTemplateSelect(t *testing.T) {
 	)
 
 	assert.Equal(
-		"SELECT * FROM artist CROSS JOIN publication",
+		"SELECT * FROM artist CROSS JOIN publication ORDER BY id() ASC",
 		b.SelectFrom("artist").CrossJoin("publication").String(),
 	)
 
 	assert.Equal(
-		"SELECT * FROM artist JOIN publication USING (id)",
+		"SELECT * FROM artist JOIN publication USING (id) ORDER BY id() ASC",
 		b.SelectFrom("artist").Join("publication").Using("id").String(),
 	)
 

--- a/ql/template_test.go
+++ b/ql/template_test.go
@@ -43,7 +43,7 @@ func TestTemplateSelect(t *testing.T) {
 	)
 
 	assert.Equal(
-		"SELECT * FROM artist LIMIT -1 OFFSET 5",
+		"SELECT * FROM artist OFFSET 5",
 		b.Select().From("artist").Limit(-1).Offset(5).String(),
 	)
 


### PR DESCRIPTION
Pagination lets you split the results of a query into chunks containing a fixed number of items.

The PR here will add the same pagination tools for both `db.Result` and `sqlbuilder.Selector`. 

## Simple pagination

```go
res = sess.Collection("posts").Paginate(20) // 20 results per page

err = res.All(&posts) // First 20 results of the query

err = res.Page(2).All(&posts) // Results from page 2 (limit 20, offset 40)
```

Or with the SQL builder:

```go
q = sess.SelectFrom("posts").Paginate(20) 

// same as above
```

## Cursor based pagination

```go
res = sess.Collection("posts").
  Paginate(20). // 20 results per page
  Cursor("id") // using id as cursor

err = res.All(&posts) // First 20 results of the query

// Get the next 20 results starting from the last item of the previous query.
res = res.NextPage(posts[len(posts)-1].ID)
err = res.All(&posts) // Results from page 1, limit 20, offset 20
```

## Other tools

```go
res = res.Paginate(23)

totalNumberOfEntries, err = res.TotalEntries()

totalNumberOfPages, err = res.TotalPages()
```



The first page from a paginator is always 0.