### PR TITLE
postgresql: use pq values instead of stringarray, int64array, etc.

### DIFF
--- a/lib/sqlbuilder/builder.go
+++ b/lib/sqlbuilder/builder.go
@@ -87,6 +87,10 @@ var (
 	sqlPlaceholder = exql.RawValue(`?`)
 )
 
+var (
+	errDeprecatedTag = errors.New("Tag %v is deprecated, please use type %v instead")
+)
+
 type exprDB interface {
 	StatementPrepare(ctx context.Context, stmt *exql.Statement) (*sql.Stmt, error)
 	StatementQuery(ctx context.Context, stmt *exql.Statement, args ...interface{}) (*sql.Rows, error)
@@ -268,10 +272,19 @@ func Map(item interface{}, options *MapOptions) ([]string, []interface{}, error)
 
 		for _, fi := range fieldMap {
 
+			// Check for deprecated tags and give suggestions on how to fix them.
+			deprecatedTags := map[string]string{
+				"stringarray": "postgresql.StringArray",
+				"int64array":  "postgresql.Int64Array",
+			}
+			for k, v := range deprecatedTags {
+				if _, hasDeprecatedTag := fi.Options[k]; hasDeprecatedTag {
+					return nil, nil, fmt.Errorf(errDeprecatedTag.Error(), k, v)
+				}
+			}
+
 			// Field options
 			_, tagOmitEmpty := fi.Options["omitempty"]
-			_, tagStringArray := fi.Options["stringarray"]
-			_, tagInt64Array := fi.Options["int64array"]
 			_, tagJSONB := fi.Options["jsonb"]
 
 			fld := reflectx.FieldByIndexesReadOnly(itemV, fi.Index)
@@ -290,18 +303,6 @@ func Map(item interface{}, options *MapOptions) ([]string, []interface{}, error)
 
 			var value interface{}
 			switch {
-			case tagStringArray:
-				v, ok := fld.Interface().([]string)
-				if !ok {
-					return nil, nil, fmt.Errorf(`Expecting field %q to be []string (using "stringarray" tag)`, fi.Name)
-				}
-				value = stringArray(v)
-			case tagInt64Array:
-				v, ok := fld.Interface().([]int64)
-				if !ok {
-					return nil, nil, fmt.Errorf(`Expecting field %q to be []int64 (using "int64array" tag)`, fi.Name)
-				}
-				value = int64Array(v)
 			case tagJSONB:
 				value = jsonbType{fld.Interface()}
 			default:

--- a/postgresql/Makefile
+++ b/postgresql/Makefile
@@ -7,6 +7,8 @@ DB_USERNAME ?= upperio_tests
 DB_PASSWORD ?= upperio_secret
 DB_NAME     ?= upperio_tests
 
+TEST_FLAGS ?=
+
 export DB_HOST
 export DB_NAME
 export DB_PASSWORD
@@ -42,4 +44,4 @@ reset-db: require-client
 
 test: reset-db generate
 	#go test -tags generated -v -race # race: limit on 8192 simultaneously alive goroutines is exceeded, dying
-	go test -tags generated -v
+	go test -tags generated -v $(TEST_FLAGS)

--- a/postgresql/adapter_test.go
+++ b/postgresql/adapter_test.go
@@ -156,6 +156,8 @@ func tearUp() error {
 			string_value varchar(255),
 
 			auto_jsonb jsonb,
+			auto_jsonb_map jsonb,
+			auto_jsonb_array jsonb,
 			custom_jsonb jsonb,
 			auto_jsonb_ptr jsonb,
 
@@ -226,6 +228,8 @@ func testPostgreSQLTypes(t *testing.T, sess sqlbuilder.Database) {
 		AutoIntegerArray Int64Array  `db:"auto_integer_array"`
 		AutoStringArray  StringArray `db:"auto_string_array"`
 		AutoJSONB        JSONB       `db:"auto_jsonb"`
+		AutoJSONBMap     JSONBMap    `db:"auto_jsonb_map"`
+		AutoJSONBArray   JSONBArray  `db:"auto_jsonb_array"`
 		CustomJSONB      customJSONB `db:"custom_jsonb"`
 
 		AutoIntegerArrayPtr *Int64Array  `db:"auto_integer_array_ptr,omitempty"`
@@ -253,8 +257,23 @@ func testPostgreSQLTypes(t *testing.T, sess sqlbuilder.Database) {
 			AutoIntegerArrayPtr: nil,
 		},
 		PGType{
+			AutoJSONBMap: JSONBMap{
+				"Hello": "world",
+				"Roses": "red",
+			},
+			AutoJSONBArray: JSONBArray{float64(1), float64(2), float64(3), float64(4)},
+		},
+		PGType{
 			AutoIntegerArray:    nil,
 			AutoIntegerArrayPtr: &Int64Array{4, 5, 6, 7},
+		},
+		PGType{
+			AutoJSONBMap:   JSONBMap{},
+			AutoJSONBArray: JSONBArray{},
+		},
+		PGType{
+			AutoJSONBMap:   JSONBMap(nil),
+			AutoJSONBArray: JSONBArray(nil),
 		},
 		PGType{
 			AutoStringArray:    StringArray{"aaa", "bbb", "ccc"},

--- a/postgresql/adapter_test.go
+++ b/postgresql/adapter_test.go
@@ -696,10 +696,10 @@ func TestTextMode_Issue391(t *testing.T) {
 }
 
 func TestBinaryMode_Issue391(t *testing.T) {
-	settingsWithBinary := settings
-	settingsWithBinary.Options["binary_parameters"] = "yes"
+	settingsWithBinaryMode := settings
+	settingsWithBinaryMode.Options["binary_parameters"] = "yes"
 
-	sess, err := Open(settingsWithBinary)
+	sess, err := Open(settingsWithBinaryMode)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/postgresql/adapter_test.go
+++ b/postgresql/adapter_test.go
@@ -190,228 +190,13 @@ func tearUp() error {
 	return nil
 }
 
-func TestOptionTypes(t *testing.T) {
-	sess := mustOpen()
-	defer sess.Close()
-
-	optionTypes := sess.Collection("option_types")
-	err := optionTypes.Truncate()
-	assert.NoError(t, err)
-
-	// TODO: lets do some benchmarking on these auto-wrapped option types..
-
-	// TODO: add nullable jsonb field mapped to a []string
-
-	// A struct with wrapped option types defined in the struct tags
-	// for postgres string array and jsonb types
-	type optionType struct {
-		ID       int64                  `db:"id,omitempty"`
-		Name     string                 `db:"name"`
-		Tags     []string               `db:"tags,stringarray"`
-		Settings map[string]interface{} `db:"settings,jsonb"`
-	}
-
-	// Item 1
-	item1 := optionType{
-		Name:     "Food",
-		Tags:     []string{"toronto", "pizza"},
-		Settings: map[string]interface{}{"a": 1, "b": 2},
-	}
-
-	id, err := optionTypes.Insert(item1)
-	assert.NoError(t, err)
-
-	if pk, ok := id.(int64); !ok || pk == 0 {
-		t.Fatalf("Expecting an ID.")
-	}
-
-	var item1Chk optionType
-	err = optionTypes.Find(db.Cond{"id": id}).One(&item1Chk)
-	assert.NoError(t, err)
-
-	assert.Equal(t, float64(1), item1Chk.Settings["a"])
-	assert.Equal(t, "toronto", item1Chk.Tags[0])
-
-	// Item 1 B
-	item1b := &optionType{
-		Name:     "Golang",
-		Tags:     []string{"love", "it"},
-		Settings: map[string]interface{}{"go": 1, "lang": 2},
-	}
-
-	id, err = optionTypes.Insert(item1b)
-	assert.NoError(t, err)
-
-	if pk, ok := id.(int64); !ok || pk == 0 {
-		t.Fatalf("Expecting an ID.")
-	}
-
-	var item1bChk optionType
-	err = optionTypes.Find(db.Cond{"id": id}).One(&item1bChk)
-	assert.NoError(t, err)
-
-	assert.Equal(t, float64(1), item1bChk.Settings["go"])
-	assert.Equal(t, "love", item1bChk.Tags[0])
-
-	// Item 1 C
-	item1c := &optionType{
-		Name: "Sup", Tags: []string{}, Settings: map[string]interface{}{},
-	}
-
-	id, err = optionTypes.Insert(item1c)
-	assert.NoError(t, err)
-
-	if pk, ok := id.(int64); !ok || pk == 0 {
-		t.Fatalf("Expecting an ID.")
-	}
-
-	var item1cChk optionType
-	err = optionTypes.Find(db.Cond{"id": id}).One(&item1cChk)
-	assert.NoError(t, err)
-
-	assert.Zero(t, len(item1cChk.Tags))
-	assert.Zero(t, len(item1cChk.Settings))
-
-	// An option type to pointer jsonb field
-	type optionType2 struct {
-		ID       int64                   `db:"id,omitempty"`
-		Name     string                  `db:"name"`
-		Tags     []string                `db:"tags,stringarray"`
-		Settings *map[string]interface{} `db:"settings,jsonb"`
-	}
-
-	item2 := optionType2{
-		Name: "JS", Tags: []string{"hi", "bye"}, Settings: nil,
-	}
-
-	id, err = optionTypes.Insert(item2)
-	assert.NoError(t, err)
-
-	if pk, ok := id.(int64); !ok || pk == 0 {
-		t.Fatalf("Expecting an ID.")
-	}
-
-	var item2Chk optionType2
-	res := optionTypes.Find(db.Cond{"id": id})
-	err = res.One(&item2Chk)
-	assert.NoError(t, err)
-
-	assert.Equal(t, id.(int64), item2Chk.ID)
-
-	assert.Equal(t, item2Chk.Name, item2.Name)
-
-	assert.Equal(t, item2Chk.Tags[0], item2.Tags[0])
-	assert.Equal(t, len(item2Chk.Tags), len(item2.Tags))
-
-	// Update the value
-	m := map[string]interface{}{}
-	m["lang"] = "javascript"
-	m["num"] = 31337
-	item2.Settings = &m
-	err = res.Update(item2)
-	assert.NoError(t, err)
-
-	err = res.One(&item2Chk)
-	assert.NoError(t, err)
-
-	assert.Equal(t, float64(31337), (*item2Chk.Settings)["num"].(float64))
-
-	assert.Equal(t, "javascript", (*item2Chk.Settings)["lang"])
-
-	// An option type to pointer string array field
-	type optionType3 struct {
-		ID       int64                  `db:"id,omitempty"`
-		Name     string                 `db:"name"`
-		Tags     *[]string              `db:"tags,stringarray"`
-		Settings map[string]interface{} `db:"settings,jsonb"`
-	}
-
-	item3 := optionType3{
-		Name:     "Julia",
-		Tags:     nil,
-		Settings: map[string]interface{}{"girl": true, "lang": true},
-	}
-
-	id, err = optionTypes.Insert(item3)
-	assert.NoError(t, err)
-
-	if pk, ok := id.(int64); !ok || pk == 0 {
-		t.Fatalf("Expecting an ID.")
-	}
-
-	var item3Chk optionType2
-	err = optionTypes.Find(db.Cond{"id": id}).One(&item3Chk)
-	assert.NoError(t, err)
-}
-
-func TestOptionTypeJsonbStruct(t *testing.T) {
-	sess := mustOpen()
-	defer sess.Close()
-
-	optionTypes := sess.Collection("option_types")
-
-	err := optionTypes.Truncate()
-	assert.NoError(t, err)
-
-	// A struct with wrapped option types defined in the struct tags
-	// for postgres string array and jsonb types
-	type Settings struct {
-		Name string `json:"name"`
-		Num  int64  `json:"num"`
-	}
-
-	type OptionType struct {
-		ID       int64    `db:"id,omitempty"`
-		Name     string   `db:"name"`
-		Tags     []string `db:"tags,stringarray"`
-		Settings Settings `db:"settings,jsonb"`
-	}
-
-	item1 := &OptionType{
-		Name:     "Hi",
-		Tags:     []string{"aah", "ok"},
-		Settings: Settings{Name: "a", Num: 123},
-	}
-
-	id, err := optionTypes.Insert(item1)
-	assert.NoError(t, err)
-
-	if pk, ok := id.(int64); !ok || pk == 0 {
-		t.Fatalf("Expecting an ID.")
-	}
-
-	var item1Chk OptionType
-	err = optionTypes.Find(db.Cond{"id": id}).One(&item1Chk)
-	assert.NoError(t, err)
-
-	assert.Equal(t, 2, len(item1Chk.Tags))
-	assert.Equal(t, "aah", item1Chk.Tags[0])
-	assert.Equal(t, "a", item1Chk.Settings.Name)
-	assert.Equal(t, int64(123), item1Chk.Settings.Num)
-}
-
-func TestSchemaCollection(t *testing.T) {
-	sess := mustOpen()
-	defer sess.Close()
-
-	col := sess.Collection("test_schema.test")
-	_, err := col.Insert(map[string]int{"id": 9})
-	assert.Equal(t, nil, err)
-
-	var dump []map[string]int
-	err = col.Find().All(&dump)
-	assert.Nil(t, err)
-	assert.Equal(t, 1, len(dump))
-	assert.Equal(t, 9, dump[0]["id"])
-}
-
-func TestPgTypes(t *testing.T) {
+func testPostgreSQLTypes(t *testing.T, sess sqlbuilder.Database) {
 	type PGType struct {
 		ID int64 `db:"id,omitempty"`
 
-		IntegerArray []int64  `db:"integer_array,int64array"`
-		StringValue  *string  `db:"string_value,omitempty"`
-		StringArray  []string `db:"string_array,stringarray"`
+		IntegerArray Int64Array  `db:"integer_array"`
+		StringValue  *string     `db:"string_value,omitempty"`
+		StringArray  StringArray `db:"string_array"`
 
 		Field1 *int64   `db:"field1,omitempty"`
 		Field2 *string  `db:"field2,omitempty"`
@@ -511,9 +296,6 @@ func TestPgTypes(t *testing.T) {
 		},
 	}
 
-	sess := mustOpen()
-	defer sess.Close()
-
 	for i := 0; i < 100; i++ {
 
 		pgTypeTests := make([]PGType, len(origPgTypeTests))
@@ -571,6 +353,221 @@ func TestPgTypes(t *testing.T) {
 		err = batch.Wait()
 		assert.NoError(t, err)
 	}
+}
+
+func TestOptionTypes(t *testing.T) {
+	sess := mustOpen()
+	defer sess.Close()
+
+	optionTypes := sess.Collection("option_types")
+	err := optionTypes.Truncate()
+	assert.NoError(t, err)
+
+	// TODO: lets do some benchmarking on these auto-wrapped option types..
+
+	// TODO: add nullable jsonb field mapped to a []string
+
+	// A struct with wrapped option types defined in the struct tags
+	// for postgres string array and jsonb types
+	type optionType struct {
+		ID       int64                  `db:"id,omitempty"`
+		Name     string                 `db:"name"`
+		Tags     StringArray            `db:"tags"`
+		Settings map[string]interface{} `db:"settings,jsonb"`
+	}
+
+	// Item 1
+	item1 := optionType{
+		Name:     "Food",
+		Tags:     []string{"toronto", "pizza"},
+		Settings: map[string]interface{}{"a": 1, "b": 2},
+	}
+
+	id, err := optionTypes.Insert(item1)
+	assert.NoError(t, err)
+
+	if pk, ok := id.(int64); !ok || pk == 0 {
+		t.Fatalf("Expecting an ID.")
+	}
+
+	var item1Chk optionType
+	err = optionTypes.Find(db.Cond{"id": id}).One(&item1Chk)
+	assert.NoError(t, err)
+
+	assert.Equal(t, float64(1), item1Chk.Settings["a"])
+	assert.Equal(t, "toronto", item1Chk.Tags[0])
+
+	// Item 1 B
+	item1b := &optionType{
+		Name:     "Golang",
+		Tags:     []string{"love", "it"},
+		Settings: map[string]interface{}{"go": 1, "lang": 2},
+	}
+
+	id, err = optionTypes.Insert(item1b)
+	assert.NoError(t, err)
+
+	if pk, ok := id.(int64); !ok || pk == 0 {
+		t.Fatalf("Expecting an ID.")
+	}
+
+	var item1bChk optionType
+	err = optionTypes.Find(db.Cond{"id": id}).One(&item1bChk)
+	assert.NoError(t, err)
+
+	assert.Equal(t, float64(1), item1bChk.Settings["go"])
+	assert.Equal(t, "love", item1bChk.Tags[0])
+
+	// Item 1 C
+	item1c := &optionType{
+		Name: "Sup", Tags: []string{}, Settings: map[string]interface{}{},
+	}
+
+	id, err = optionTypes.Insert(item1c)
+	assert.NoError(t, err)
+
+	if pk, ok := id.(int64); !ok || pk == 0 {
+		t.Fatalf("Expecting an ID.")
+	}
+
+	var item1cChk optionType
+	err = optionTypes.Find(db.Cond{"id": id}).One(&item1cChk)
+	assert.NoError(t, err)
+
+	assert.Zero(t, len(item1cChk.Tags))
+	assert.Zero(t, len(item1cChk.Settings))
+
+	// An option type to pointer jsonb field
+	type optionType2 struct {
+		ID       int64                   `db:"id,omitempty"`
+		Name     string                  `db:"name"`
+		Tags     StringArray             `db:"tags"`
+		Settings *map[string]interface{} `db:"settings,jsonb"`
+	}
+
+	item2 := optionType2{
+		Name: "JS", Tags: []string{"hi", "bye"}, Settings: nil,
+	}
+
+	id, err = optionTypes.Insert(item2)
+	assert.NoError(t, err)
+
+	if pk, ok := id.(int64); !ok || pk == 0 {
+		t.Fatalf("Expecting an ID.")
+	}
+
+	var item2Chk optionType2
+	res := optionTypes.Find(db.Cond{"id": id})
+	err = res.One(&item2Chk)
+	assert.NoError(t, err)
+
+	assert.Equal(t, id.(int64), item2Chk.ID)
+
+	assert.Equal(t, item2Chk.Name, item2.Name)
+
+	assert.Equal(t, item2Chk.Tags[0], item2.Tags[0])
+	assert.Equal(t, len(item2Chk.Tags), len(item2.Tags))
+
+	// Update the value
+	m := map[string]interface{}{}
+	m["lang"] = "javascript"
+	m["num"] = 31337
+	item2.Settings = &m
+	err = res.Update(item2)
+	assert.NoError(t, err)
+
+	err = res.One(&item2Chk)
+	assert.NoError(t, err)
+
+	assert.Equal(t, float64(31337), (*item2Chk.Settings)["num"].(float64))
+
+	assert.Equal(t, "javascript", (*item2Chk.Settings)["lang"])
+
+	// An option type to pointer string array field
+	type optionType3 struct {
+		ID       int64                  `db:"id,omitempty"`
+		Name     string                 `db:"name"`
+		Tags     *StringArray           `db:"tags"`
+		Settings map[string]interface{} `db:"settings,jsonb"`
+	}
+
+	item3 := optionType3{
+		Name:     "Julia",
+		Tags:     nil,
+		Settings: map[string]interface{}{"girl": true, "lang": true},
+	}
+
+	id, err = optionTypes.Insert(item3)
+	assert.NoError(t, err)
+
+	if pk, ok := id.(int64); !ok || pk == 0 {
+		t.Fatalf("Expecting an ID.")
+	}
+
+	var item3Chk optionType2
+	err = optionTypes.Find(db.Cond{"id": id}).One(&item3Chk)
+	assert.NoError(t, err)
+}
+
+func TestOptionTypeJsonbStruct(t *testing.T) {
+	sess := mustOpen()
+	defer sess.Close()
+
+	optionTypes := sess.Collection("option_types")
+
+	err := optionTypes.Truncate()
+	assert.NoError(t, err)
+
+	// A struct with wrapped option types defined in the struct tags
+	// for postgres string array and jsonb types
+	type Settings struct {
+		Name string `json:"name"`
+		Num  int64  `json:"num"`
+	}
+
+	type OptionType struct {
+		ID       int64       `db:"id,omitempty"`
+		Name     string      `db:"name"`
+		Tags     StringArray `db:"tags"`
+		Settings Settings    `db:"settings,jsonb"`
+	}
+
+	item1 := &OptionType{
+		Name:     "Hi",
+		Tags:     []string{"aah", "ok"},
+		Settings: Settings{Name: "a", Num: 123},
+	}
+
+	id, err := optionTypes.Insert(item1)
+	assert.NoError(t, err)
+
+	if pk, ok := id.(int64); !ok || pk == 0 {
+		t.Fatalf("Expecting an ID.")
+	}
+
+	var item1Chk OptionType
+	err = optionTypes.Find(db.Cond{"id": id}).One(&item1Chk)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 2, len(item1Chk.Tags))
+	assert.Equal(t, "aah", item1Chk.Tags[0])
+	assert.Equal(t, "a", item1Chk.Settings.Name)
+	assert.Equal(t, int64(123), item1Chk.Settings.Num)
+}
+
+func TestSchemaCollection(t *testing.T) {
+	sess := mustOpen()
+	defer sess.Close()
+
+	col := sess.Collection("test_schema.test")
+	_, err := col.Insert(map[string]int{"id": 9})
+	assert.Equal(t, nil, err)
+
+	var dump []map[string]int
+	err = col.Find().All(&dump)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(dump))
+	assert.Equal(t, 9, dump[0]["id"])
 }
 
 func TestMaxOpenConns_Issue340(t *testing.T) {
@@ -689,6 +686,26 @@ func TestUUIDInsert_Issue370(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, item1.Name, item3.Name)
 	}
+}
+
+func TestTextMode_Issue391(t *testing.T) {
+	sess := mustOpen()
+	defer sess.Close()
+
+	testPostgreSQLTypes(t, sess)
+}
+
+func TestBinaryMode_Issue391(t *testing.T) {
+	settingsWithBinary := settings
+	settingsWithBinary.Options["binary_parameters"] = "yes"
+
+	sess, err := Open(settingsWithBinary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sess.Close()
+
+	testPostgreSQLTypes(t, sess)
 }
 
 func getStats(sess sqlbuilder.Database) (map[string]int, error) {

--- a/postgresql/custom_types.go
+++ b/postgresql/custom_types.go
@@ -55,7 +55,7 @@ func (j *JSONB) Scan(src interface{}) error {
 		return errors.New("Scan source was not []bytes")
 	}
 
-	v := JSONB{}
+	v := JSONB{j.V}
 	if err := json.Unmarshal(b, &v.V); err != nil {
 		return err
 	}
@@ -168,6 +168,19 @@ func (g *GenericArray) Scan(src interface{}) error {
 	}
 	*g = GenericArray(s)
 	return nil
+}
+
+// EncodeJSONB takes an interface and provides a driver.Value that can be
+// stored as a JSONB column.
+func EncodeJSONB(i interface{}) (driver.Value, error) {
+	v := JSONB{i}
+	return v.Value()
+}
+
+// DecodeJSONB decodes a JSON byte stream into the passed dst value.
+func DecodeJSONB(dst interface{}, src interface{}) error {
+	v := JSONB{dst}
+	return v.Scan(src)
 }
 
 type scannerValuer interface {

--- a/postgresql/custom_types.go
+++ b/postgresql/custom_types.go
@@ -22,12 +22,11 @@
 package postgresql
 
 import (
+	"database/sql"
 	"database/sql/driver"
 	"encoding/json"
 	"errors"
-	"fmt"
-	"strconv"
-	"strings"
+	"github.com/lib/pq"
 )
 
 const (
@@ -39,7 +38,7 @@ const (
 	stateStop
 )
 
-// Type JSONB represents a PostgreSQL's JSONB column.
+// Type JSONB represents a PostgreSQL's JSONB value.
 type JSONB struct {
 	V interface{}
 }
@@ -66,202 +65,120 @@ func (j *JSONB) Scan(src interface{}) error {
 
 // Value implements the driver.Valuer interface.
 func (j JSONB) Value() (driver.Value, error) {
+	// See https://github.com/lib/pq/issues/528#issuecomment-257197239 on why are
+	// we returning string instead of []byte.
 	if j.V == nil {
 		return nil, nil
 	}
 	if v, ok := j.V.(json.RawMessage); ok {
 		return string(v), nil
 	}
-	return json.Marshal(j.V)
+	b, err := json.Marshal(j.V)
+	if err != nil {
+		return nil, err
+	}
+	return string(b), nil
 }
 
-// StringArray represents a PostgreSQL's varchar array.
-type StringArray []string
-
-// Scan implements the sql.Scanner interface.
-func (a *StringArray) Scan(src interface{}) error {
-	if src == nil {
-		*a = nil
-		return nil
-	}
-
-	b, ok := src.([]byte)
-	if !ok {
-		return errors.New("Scan source was not []bytes")
-	}
-	if len(b) == 0 {
-		*a = nil
-		return nil
-	}
-
-	results := []string{}
-
-	state := stateOpenBracket
-	var buffer []byte
-
-	for i := 1; i < len(b); i++ {
-		c := b[i]
-
-		switch state {
-		case stateStop:
-			return fmt.Errorf("Got additional data beyond expected bounds")
-		case stateInit:
-			switch c {
-			case '{':
-				buffer = nil
-				state = stateOpenBracket
-			default:
-				return fmt.Errorf("Expecting { at position %d", i)
-			}
-		case stateOpenBracket:
-			switch c {
-			case '}':
-				if buffer != nil {
-					results = append(results, string(buffer))
-				}
-				state = stateStop
-				break
-			case ' ':
-				continue
-			case ',':
-				results = append(results, string(buffer))
-				buffer = []byte{}
-				continue
-			case '"':
-				state = stateOpenQuote
-				buffer = []byte{}
-			default:
-				state = stateLiteral
-				buffer = []byte{c}
-			}
-		case stateLiteral:
-			switch c {
-			case '}':
-				results = append(results, string(buffer))
-				state = stateStop
-			case ',':
-				results = append(results, string(buffer))
-				buffer = []byte{}
-
-				state = stateOpenBracket
-			default:
-				buffer = append(buffer, c)
-			}
-		case stateEscape:
-			buffer = append(buffer, c)
-			state = stateOpenQuote
-		case stateOpenQuote:
-			switch c {
-			case '\\':
-				state = stateEscape
-				continue
-			case '"':
-				state = stateOpenBracket
-			default:
-				buffer = append(buffer, c)
-			}
-		}
-	}
-
-	*a = StringArray(results)
-	return nil
-}
+// Type StringArray is an alias for pq.StringArray
+type StringArray pq.StringArray
 
 // Value implements the driver.Valuer interface.
 func (a StringArray) Value() (driver.Value, error) {
-	if a == nil {
-		return nil, nil
-	}
-
-	if n := len(a); n > 0 {
-		// There will be at least two curly brackets, 2*N bytes of quotes,
-		// and N-1 bytes of delimiters.
-		b := make([]byte, 1, 1+3*n)
-		b[0] = '{'
-
-		b = appendArrayQuotedString(b, a[0])
-		for i := 1; i < n; i++ {
-			b = append(b, ',')
-			b = appendArrayQuotedString(b, a[i])
-		}
-
-		return append(b, '}'), nil
-	}
-
-	return []byte{'{', '}'}, nil
+	return pq.StringArray(a).Value()
 }
-
-func appendArrayQuotedString(b []byte, v string) []byte {
-	b = append(b, '"')
-	for {
-		i := strings.IndexAny(v, `"\`)
-		if i < 0 {
-			b = append(b, v...)
-			break
-		}
-		if i > 0 {
-			b = append(b, v[:i]...)
-		}
-		b = append(b, '\\', v[i])
-		v = v[i+1:]
-	}
-	return append(b, '"')
-}
-
-// Int64Array represents a PostgreSQL's integer array.
-type Int64Array []int64
 
 // Scan implements the sql.Scanner interface.
-func (a *Int64Array) Scan(src interface{}) error {
-	if src == nil {
-		*a = nil
-		return nil
+func (a *StringArray) Scan(src interface{}) error {
+	s := pq.StringArray(*a)
+	if err := s.Scan(src); err != nil {
+		return err
 	}
-	b, ok := src.([]byte)
-	if !ok {
-		return errors.New("Scan source was not []bytes")
-	}
-	if len(b) == 0 {
-		*a = nil
-		return nil
-	}
-
-	s := string(b)[1 : len(b)-1]
-	results := []int64{}
-	if s != "" {
-		parts := strings.Split(s, ",")
-		for _, n := range parts {
-			i, err := strconv.ParseInt(n, 10, 64)
-			if err != nil {
-				return err
-			}
-			results = append(results, i)
-		}
-	}
-	*a = Int64Array(results)
+	*a = StringArray(s)
 	return nil
 }
 
+// Type Int64Array is an alias for pq.Int64Array
+type Int64Array pq.Int64Array
+
 // Value implements the driver.Valuer interface.
-func (a Int64Array) Value() (driver.Value, error) {
-	if a == nil {
-		return nil, nil
-	}
-
-	if n := len(a); n > 0 {
-		// There will be at least two curly brackets, N bytes of values,
-		// and N-1 bytes of delimiters.
-		b := make([]byte, 1, 1+2*n)
-		b[0] = '{'
-
-		b = strconv.AppendInt(b, a[0], 10)
-		for i := 1; i < n; i++ {
-			b = append(b, ',')
-			b = strconv.AppendInt(b, a[i], 10)
-		}
-
-		return append(b, '}'), nil
-	}
-
-	return []byte{'{', '}'}, nil
+func (i Int64Array) Value() (driver.Value, error) {
+	return pq.Int64Array(i).Value()
 }
+
+// Scan implements the sql.Scanner interface.
+func (i *Int64Array) Scan(src interface{}) error {
+	s := pq.Int64Array(*i)
+	if err := s.Scan(src); err != nil {
+		return err
+	}
+	*i = Int64Array(s)
+	return nil
+}
+
+// Type Float64Array is an alias for pq.Float64Array
+type Float64Array pq.Float64Array
+
+// Value implements the driver.Valuer interface.
+func (f Float64Array) Value() (driver.Value, error) {
+	return pq.Float64Array(f).Value()
+}
+
+// Scan implements the sql.Scanner interface.
+func (f *Float64Array) Scan(src interface{}) error {
+	s := pq.Float64Array(*f)
+	if err := s.Scan(src); err != nil {
+		return err
+	}
+	*f = Float64Array(s)
+	return nil
+}
+
+// Type BoolArray is an alias for pq.BoolArray
+type BoolArray pq.BoolArray
+
+// Value implements the driver.Valuer interface.
+func (b BoolArray) Value() (driver.Value, error) {
+	return pq.BoolArray(b).Value()
+}
+
+// Scan implements the sql.Scanner interface.
+func (b *BoolArray) Scan(src interface{}) error {
+	s := pq.BoolArray(*b)
+	if err := s.Scan(src); err != nil {
+		return err
+	}
+	*b = BoolArray(s)
+	return nil
+}
+
+// Type GenericArray is an alias for pq.GenericArray
+type GenericArray pq.GenericArray
+
+// Value implements the driver.Valuer interface.
+func (g GenericArray) Value() (driver.Value, error) {
+	return pq.GenericArray(g).Value()
+}
+
+// Scan implements the sql.Scanner interface.
+func (g *GenericArray) Scan(src interface{}) error {
+	s := pq.GenericArray(*g)
+	if err := s.Scan(src); err != nil {
+		return err
+	}
+	*g = GenericArray(s)
+	return nil
+}
+
+type scannerValuer interface {
+	driver.Valuer
+	sql.Scanner
+}
+
+var (
+	_ = scannerValuer(&StringArray{})
+	_ = scannerValuer(&Int64Array{})
+	_ = scannerValuer(&Float64Array{})
+	_ = scannerValuer(&BoolArray{})
+	_ = scannerValuer(&GenericArray{})
+)

--- a/postgresql/custom_types.go
+++ b/postgresql/custom_types.go
@@ -170,6 +170,27 @@ func (g *GenericArray) Scan(src interface{}) error {
 	return nil
 }
 
+type JSONBMap map[string]interface{}
+
+func (m JSONBMap) Value() (driver.Value, error) {
+	return EncodeJSONB(m)
+}
+
+func (m *JSONBMap) Scan(src interface{}) error {
+	*m = map[string]interface{}(nil)
+	return DecodeJSONB(m, src)
+}
+
+type JSONBArray []interface{}
+
+func (a JSONBArray) Value() (driver.Value, error) {
+	return EncodeJSONB(a)
+}
+
+func (a *JSONBArray) Scan(src interface{}) error {
+	return DecodeJSONB(a, src)
+}
+
 // EncodeJSONB takes an interface and provides a driver.Value that can be
 // stored as a JSONB column.
 func EncodeJSONB(i interface{}) (driver.Value, error) {
@@ -194,4 +215,6 @@ var (
 	_ = scannerValuer(&Float64Array{})
 	_ = scannerValuer(&BoolArray{})
 	_ = scannerValuer(&GenericArray{})
+	_ = scannerValuer(&JSONBMap{})
+	_ = scannerValuer(&JSONBArray{})
 )

--- a/postgresql/local_test.go
+++ b/postgresql/local_test.go
@@ -31,9 +31,9 @@ func TestStringAndInt64Array(t *testing.T) {
 	assert.NoError(t, err)
 
 	type arrayType struct {
-		ID       int64    `db:"id,pk"`
-		Integers []int64  `db:"integers,int64array"`
-		Strings  []string `db:"strings,stringarray"`
+		ID       int64       `db:"id,pk"`
+		Integers Int64Array  `db:"integers"`
+		Strings  StringArray `db:"strings"`
 	}
 
 	tt := []arrayType{


### PR DESCRIPTION
This will deprecate stringarray, int64array. Users will need to move to
postgresql.StringArray, postgresql.Int64Array, etc.