### PR TITLE
db: add ConvertValues to auto-convert native Go values into adapter values

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,8 @@ notifications:
 language: go
 
 go:
-  - "1.7"
   - "1.8"
-# - "tip"
+  - "tip"
 
 services:
   - docker

--- a/internal/sqladapter/database.go
+++ b/internal/sqladapter/database.go
@@ -32,6 +32,10 @@ type hasStatementExec interface {
 	StatementExec(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
 }
 
+type hasConvertValues interface {
+	ConvertValues(values []interface{}) []interface{}
+}
+
 // Database represents a SQL database.
 type Database interface {
 	PartialDatabase
@@ -391,6 +395,14 @@ func (d *database) StatementPrepare(ctx context.Context, stmt *exql.Statement) (
 	return
 }
 
+// ConvertValues converts native values into driver specific values.
+func (d *database) ConvertValues(values []interface{}) []interface{} {
+	if converter, ok := d.PartialDatabase.(hasConvertValues); ok {
+		return converter.ConvertValues(values)
+	}
+	return values
+}
+
 // StatementExec compiles and executes a statement that does not return any
 // rows.
 func (d *database) StatementExec(ctx context.Context, stmt *exql.Statement, args ...interface{}) (res sql.Result, err error) {
@@ -547,6 +559,9 @@ func (d *database) Driver() interface{} {
 
 // compileStatement compiles the given statement into a string.
 func (d *database) compileStatement(stmt *exql.Statement, args []interface{}) (string, []interface{}) {
+	if converter, ok := d.PartialDatabase.(hasConvertValues); ok {
+		args = converter.ConvertValues(args)
+	}
 	return d.PartialDatabase.CompileStatement(stmt, args)
 }
 

--- a/internal/sqladapter/exql/value.go
+++ b/internal/sqladapter/exql/value.go
@@ -1,9 +1,7 @@
 package exql
 
 import (
-	//"database/sql/driver"
 	"fmt"
-	//"log"
 	"strings"
 )
 
@@ -73,18 +71,6 @@ func (v *Value) Compile(layout *Template) (compiled string, err error) {
 	return
 }
 
-/*
-func (v *Value) Scan(src interface{}) error {
-	log.Println("Scan(", src, ") on", v.V)
-	return nil
-}
-
-func (v *Value) Value() (driver.Value, error) {
-	log.Println("Value() on", v.V)
-	return v.V, nil
-}
-*/
-
 // Hash returns a unique identifier for the struct.
 func (vs *Values) Hash() string {
 	return vs.hash.Hash(vs)
@@ -111,18 +97,6 @@ func (vs *Values) Compile(layout *Template) (compiled string, err error) {
 	layout.Write(vs, compiled)
 	return
 }
-
-/*
-func (vs Values) Scan(src interface{}) error {
-	log.Println("Values.Scan(", src, ")")
-	return nil
-}
-
-func (vs Values) Value() (driver.Value, error) {
-	log.Println("Values.Value()")
-	return vs, nil
-}
-*/
 
 // Hash returns a unique identifier for the struct.
 func (vg *ValueGroups) Hash() string {

--- a/lib/sqlbuilder/builder.go
+++ b/lib/sqlbuilder/builder.go
@@ -69,6 +69,7 @@ type hasStatement interface {
 }
 
 type iterator struct {
+	sess   exprDB
 	cursor *sql.Rows // This is the main query cursor. It starts as a nil value.
 	err    error
 }
@@ -92,10 +93,10 @@ var (
 )
 
 type exprDB interface {
+	StatementExec(ctx context.Context, stmt *exql.Statement, args ...interface{}) (sql.Result, error)
 	StatementPrepare(ctx context.Context, stmt *exql.Statement) (*sql.Stmt, error)
 	StatementQuery(ctx context.Context, stmt *exql.Statement, args ...interface{}) (*sql.Rows, error)
 	StatementQueryRow(ctx context.Context, stmt *exql.Statement, args ...interface{}) (*sql.Row, error)
-	StatementExec(ctx context.Context, stmt *exql.Statement, args ...interface{}) (sql.Result, error)
 
 	Context() context.Context
 }
@@ -125,7 +126,7 @@ func WithTemplate(t *exql.Template) SQLBuilder {
 
 // NewIterator creates an iterator using the given *sql.Rows.
 func NewIterator(rows *sql.Rows) Iterator {
-	return &iterator{rows, nil}
+	return &iterator{nil, rows, nil}
 }
 
 func (b *sqlBuilder) Iterator(query interface{}, args ...interface{}) Iterator {
@@ -134,7 +135,7 @@ func (b *sqlBuilder) Iterator(query interface{}, args ...interface{}) Iterator {
 
 func (b *sqlBuilder) IteratorContext(ctx context.Context, query interface{}, args ...interface{}) Iterator {
 	rows, err := b.QueryContext(ctx, query, args...)
-	return &iterator{rows, err}
+	return &iterator{b.sess, rows, err}
 }
 
 func (b *sqlBuilder) Prepare(query interface{}) (*sql.Stmt, error) {
@@ -468,7 +469,7 @@ func (iter *iterator) All(dst interface{}) error {
 	defer iter.Close()
 
 	// Fetching all results within the cursor.
-	if err := fetchRows(iter.cursor, dst); err != nil {
+	if err := fetchRows(iter, dst); err != nil {
 		return iter.setErr(err)
 	}
 
@@ -512,7 +513,7 @@ func (iter *iterator) next(dst ...interface{}) error {
 		}
 		return nil
 	case 1:
-		if err := fetchRow(iter.cursor, dst[0]); err != nil {
+		if err := fetchRow(iter, dst[0]); err != nil {
 			defer iter.Close()
 			return err
 		}

--- a/lib/sqlbuilder/insert.go
+++ b/lib/sqlbuilder/insert.go
@@ -29,7 +29,6 @@ func (iq *inserterQuery) processValues() ([]*exql.Values, []interface{}, error) 
 	}
 
 	for _, enqueuedValue := range iq.enqueuedValues {
-
 		if len(enqueuedValue) == 1 {
 			// If and only if we passed one argument to Values.
 			ff, vv, err := Map(enqueuedValue[0], mapOptions)
@@ -206,7 +205,7 @@ func (ins *inserter) Iterator() Iterator {
 
 func (ins *inserter) IteratorContext(ctx context.Context) Iterator {
 	rows, err := ins.QueryContext(ctx)
-	return &iterator{rows, err}
+	return &iterator{ins.SQLBuilder().sess, rows, err}
 }
 
 func (ins *inserter) Into(table string) Inserter {

--- a/lib/sqlbuilder/paginate.go
+++ b/lib/sqlbuilder/paginate.go
@@ -155,7 +155,8 @@ func (pag *paginator) One(dest interface{}) error {
 func (pag *paginator) Iterator() Iterator {
 	pq, err := pag.buildWithCursor()
 	if err != nil {
-		return &iterator{nil, err}
+		sess := pq.sel.(*selector).SQLBuilder().sess
+		return &iterator{sess, nil, err}
 	}
 	return pq.sel.Iterator()
 }
@@ -163,7 +164,8 @@ func (pag *paginator) Iterator() Iterator {
 func (pag *paginator) IteratorContext(ctx context.Context) Iterator {
 	pq, err := pag.buildWithCursor()
 	if err != nil {
-		return &iterator{nil, err}
+		sess := pq.sel.(*selector).SQLBuilder().sess
+		return &iterator{sess, nil, err}
 	}
 	return pq.sel.IteratorContext(ctx)
 }

--- a/lib/sqlbuilder/select.go
+++ b/lib/sqlbuilder/select.go
@@ -472,13 +472,14 @@ func (sel *selector) Iterator() Iterator {
 }
 
 func (sel *selector) IteratorContext(ctx context.Context) Iterator {
+	sess := sel.SQLBuilder().sess
 	sq, err := sel.build()
 	if err != nil {
-		return &iterator{nil, err}
+		return &iterator{sess, nil, err}
 	}
 
-	rows, err := sel.SQLBuilder().sess.StatementQuery(ctx, sq.statement(), sq.arguments()...)
-	return &iterator{rows, err}
+	rows, err := sess.StatementQuery(ctx, sq.statement(), sq.arguments()...)
+	return &iterator{sess, rows, err}
 }
 
 func (sel *selector) Paginate(pageSize uint) Paginator {

--- a/postgresql/adapter_test.go
+++ b/postgresql/adapter_test.go
@@ -178,6 +178,10 @@ func tearUp() error {
 			, uinteger_compat_value int
 			, string_compat_value text
 
+			, integer_compat_value_jsonb_array jsonb
+			, string_compat_value_jsonb_array jsonb
+			, uinteger_compat_value_jsonb_array jsonb
+
 			, string_value_ptr varchar(255)
 			, integer_value_ptr int
 			, varchar_value_ptr varchar(64)
@@ -238,7 +242,9 @@ var (
 func testPostgreSQLTypes(t *testing.T, sess sqlbuilder.Database) {
 
 	type int64Compat int64
+
 	type uintCompat uint
+
 	type stringCompat string
 
 	type PGType struct {
@@ -276,6 +282,10 @@ func testPostgreSQLTypes(t *testing.T, sess sqlbuilder.Database) {
 		UIntCompatValue   uintCompat   `db:"uinteger_compat_value"`
 		StringCompatValue stringCompat `db:"string_compat_value"`
 
+		Int64CompatValueJSONBArray  []int64Compat  `db:"integer_compat_value_jsonb_array"`
+		UIntCompatValueJSONBArray   []uintCompat   `db:"uinteger_compat_value_jsonb_array"`
+		StringCompatValueJSONBArray []stringCompat `db:"string_compat_value_jsonb_array"`
+
 		StringValuePtr  *string  `db:"string_value_ptr,omitempty"`
 		IntegerValuePtr *int64   `db:"integer_value_ptr,omitempty"`
 		VarcharValuePtr *string  `db:"varchar_value_ptr,omitempty"`
@@ -297,6 +307,16 @@ func testPostgreSQLTypes(t *testing.T, sess sqlbuilder.Database) {
 			Int64CompatValue:  -5,
 			UIntCompatValue:   3,
 			StringCompatValue: "abc",
+		},
+		PGType{
+			Int64CompatValueJSONBArray:  []int64Compat{1, -2, 3, -4},
+			UIntCompatValueJSONBArray:   []uintCompat{1, 2, 3, 4},
+			StringCompatValueJSONBArray: []stringCompat{"a", "b", "", "c"},
+		},
+		PGType{
+			Int64CompatValueJSONBArray:  []int64Compat(nil),
+			UIntCompatValueJSONBArray:   []uintCompat(nil),
+			StringCompatValueJSONBArray: []stringCompat(nil),
 		},
 		PGType{
 			IntegerValuePtr:     &integerValue,

--- a/postgresql/adapter_test.go
+++ b/postgresql/adapter_test.go
@@ -479,17 +479,17 @@ func TestOptionTypes(t *testing.T) {
 	// A struct with wrapped option types defined in the struct tags
 	// for postgres string array and jsonb types
 	type optionType struct {
-		ID       int64       `db:"id,omitempty"`
-		Name     string      `db:"name"`
-		Tags     StringArray `db:"tags"`
-		Settings JSONBMap    `db:"settings"`
+		ID       int64                  `db:"id,omitempty"`
+		Name     string                 `db:"name"`
+		Tags     []string               `db:"tags"`
+		Settings map[string]interface{} `db:"settings"`
 	}
 
 	// Item 1
 	item1 := optionType{
 		Name:     "Food",
 		Tags:     []string{"toronto", "pizza"},
-		Settings: JSONBMap{"a": 1, "b": 2},
+		Settings: map[string]interface{}{"a": 1, "b": 2},
 	}
 
 	id, err := optionTypes.Insert(item1)

--- a/postgresql/adapter_test.go
+++ b/postgresql/adapter_test.go
@@ -165,6 +165,10 @@ func tearUp() error {
 			, custom_jsonb_object jsonb
 			, auto_custom_jsonb_object jsonb
 
+			, custom_jsonb_object_array jsonb
+			, auto_custom_jsonb_object_array jsonb
+			, auto_custom_jsonb_object_map jsonb
+
 			, string_value varchar(255)
 			, integer_value int
 			, varchar_value varchar(64)
@@ -260,6 +264,9 @@ func testPostgreSQLTypes(t *testing.T, sess sqlbuilder.Database) {
 		CustomJSONBObject     customJSONB     `db:"custom_jsonb_object"`
 		AutoCustomJSONBObject autoCustomJSONB `db:"auto_custom_jsonb_object"`
 
+		AutoCustomJSONBObjectArray []autoCustomJSONB          `db:"auto_custom_jsonb_object_array"`
+		AutoCustomJSONBObjectMap   map[string]autoCustomJSONB `db:"auto_custom_jsonb_object_map"`
+
 		StringValue  string  `db:"string_value"`
 		IntegerValue int64   `db:"integer_value"`
 		VarcharValue string  `db:"varchar_value"`
@@ -311,6 +318,22 @@ func testPostgreSQLTypes(t *testing.T, sess sqlbuilder.Database) {
 			AutoStringArray:  nil,
 		},
 		PGType{
+			AutoCustomJSONBObjectArray: []autoCustomJSONB{
+				autoCustomJSONB{
+					N: "Hello",
+				},
+				autoCustomJSONB{
+					N: "World",
+				},
+			},
+			AutoCustomJSONBObjectMap: map[string]autoCustomJSONB{
+				"a": autoCustomJSONB{
+					N: "Hello",
+				},
+				"b": autoCustomJSONB{
+					N: "World",
+				},
+			},
 			AutoJSONBMap: map[string]interface{}{
 				"Hello": "world",
 				"Roses": "red",

--- a/postgresql/adapter_test.go
+++ b/postgresql/adapter_test.go
@@ -167,6 +167,10 @@ func tearUp() error {
 			, varchar_value varchar(64)
 			, decimal_value decimal
 
+			, integer_compat_value int
+			, uinteger_compat_value int
+			, string_compat_value text
+
 			, string_value_ptr varchar(255)
 			, integer_value_ptr int
 			, varchar_value_ptr varchar(64)
@@ -219,6 +223,10 @@ var (
 
 func testPostgreSQLTypes(t *testing.T, sess sqlbuilder.Database) {
 
+	type int64Compat int64
+	type uintCompat uint
+	type stringCompat string
+
 	type PGType struct {
 		ID int64 `db:"id,omitempty"`
 
@@ -244,6 +252,10 @@ func testPostgreSQLTypes(t *testing.T, sess sqlbuilder.Database) {
 		VarcharValue string  `db:"varchar_value"`
 		DecimalValue float64 `db:"decimal_value"`
 
+		Int64CompatValue  int64Compat  `db:"integer_compat_value"`
+		UIntCompatValue   uintCompat   `db:"uinteger_compat_value"`
+		StringCompatValue stringCompat `db:"string_compat_value"`
+
 		StringValuePtr  *string  `db:"string_value_ptr,omitempty"`
 		IntegerValuePtr *int64   `db:"integer_value_ptr,omitempty"`
 		VarcharValuePtr *string  `db:"varchar_value_ptr,omitempty"`
@@ -261,6 +273,11 @@ func testPostgreSQLTypes(t *testing.T, sess sqlbuilder.Database) {
 	testValue := "Hello world!"
 
 	origPgTypeTests := []PGType{
+		PGType{
+			Int64CompatValue:  -5,
+			UIntCompatValue:   3,
+			StringCompatValue: "abc",
+		},
 		PGType{
 			IntegerValuePtr: &integerValue,
 			StringValuePtr:  &stringValue,

--- a/postgresql/adapter_test.go
+++ b/postgresql/adapter_test.go
@@ -156,6 +156,8 @@ func tearUp() error {
 			, auto_integer_array integer[]
 			, auto_string_array text[]
 			, auto_jsonb_map jsonb
+			, auto_jsonb_map_string jsonb
+			, auto_jsonb_map_integer jsonb
 
 			, jsonb_object jsonb
 			, jsonb_array jsonb
@@ -246,9 +248,11 @@ func testPostgreSQLTypes(t *testing.T, sess sqlbuilder.Database) {
 		StringArrayPtr  *StringArray `db:"string_array_ptr,omitempty"`
 		JSONBMapPtr     *JSONBMap    `db:"jsonb_map_ptr,omitempty"`
 
-		AutoIntegerArray []int64                `db:"auto_integer_array"`
-		AutoStringArray  []string               `db:"auto_string_array"`
-		AutoJSONBMap     map[string]interface{} `db:"auto_jsonb_map"`
+		AutoIntegerArray    []int64                `db:"auto_integer_array"`
+		AutoStringArray     []string               `db:"auto_string_array"`
+		AutoJSONBMap        map[string]interface{} `db:"auto_jsonb_map"`
+		AutoJSONBMapString  map[string]string      `db:"auto_jsonb_map_string"`
+		AutoJSONBMapInteger map[string]int64       `db:"auto_jsonb_map_integer"`
 
 		JSONBObject JSONB      `db:"jsonb_object"`
 		JSONBArray  JSONBArray `db:"jsonb_array"`
@@ -288,9 +292,11 @@ func testPostgreSQLTypes(t *testing.T, sess sqlbuilder.Database) {
 			StringCompatValue: "abc",
 		},
 		PGType{
-			IntegerValuePtr: &integerValue,
-			StringValuePtr:  &stringValue,
-			DecimalValuePtr: &decimalValue,
+			IntegerValuePtr:     &integerValue,
+			StringValuePtr:      &stringValue,
+			DecimalValuePtr:     &decimalValue,
+			AutoJSONBMapString:  map[string]string{"a": "x", "b": "67"},
+			AutoJSONBMapInteger: map[string]int64{"a": 12, "b": 13},
 		},
 		PGType{
 			IntegerValue: integerValue,
@@ -305,7 +311,7 @@ func testPostgreSQLTypes(t *testing.T, sess sqlbuilder.Database) {
 			AutoStringArray:  nil,
 		},
 		PGType{
-			AutoJSONBMap: JSONBMap{
+			AutoJSONBMap: map[string]interface{}{
 				"Hello": "world",
 				"Roses": "red",
 			},
@@ -315,7 +321,7 @@ func testPostgreSQLTypes(t *testing.T, sess sqlbuilder.Database) {
 			AutoIntegerArray: nil,
 		},
 		PGType{
-			AutoJSONBMap: JSONBMap{},
+			AutoJSONBMap: map[string]interface{}{},
 			JSONBArray:   JSONBArray{},
 		},
 		PGType{

--- a/postgresql/custom_types.go
+++ b/postgresql/custom_types.go
@@ -30,15 +30,6 @@ import (
 	"github.com/lib/pq"
 )
 
-const (
-	stateInit = iota
-	stateOpenBracket
-	stateOpenQuote
-	stateLiteral
-	stateEscape
-	stateStop
-)
-
 // Type JSONB represents a PostgreSQL's JSONB value.
 type JSONB struct {
 	V interface{}

--- a/postgresql/custom_types.go
+++ b/postgresql/custom_types.go
@@ -178,33 +178,33 @@ func (g *GenericArray) Scan(src interface{}) error {
 type JSONBMap map[string]interface{}
 
 func (m JSONBMap) Value() (driver.Value, error) {
-	return EncodeJSONB(m)
+	return ToJSONBValue(m)
 }
 
 func (m *JSONBMap) Scan(src interface{}) error {
 	*m = map[string]interface{}(nil)
-	return DecodeJSONB(m, src)
+	return FromJSONBValue(m, src)
 }
 
 type JSONBArray []interface{}
 
 func (a JSONBArray) Value() (driver.Value, error) {
-	return EncodeJSONB(a)
+	return ToJSONBValue(a)
 }
 
 func (a *JSONBArray) Scan(src interface{}) error {
-	return DecodeJSONB(a, src)
+	return FromJSONBValue(a, src)
 }
 
-// EncodeJSONB takes an interface and provides a driver.Value that can be
+// ToJSONBValue takes an interface and provides a driver.Value that can be
 // stored as a JSONB column.
-func EncodeJSONB(i interface{}) (driver.Value, error) {
+func ToJSONBValue(i interface{}) (driver.Value, error) {
 	v := JSONB{i}
 	return v.Value()
 }
 
-// DecodeJSONB decodes a JSON byte stream into the passed dst value.
-func DecodeJSONB(dst interface{}, src interface{}) error {
+// FromJSONBValue decodes a JSON byte stream into the passed dst value.
+func FromJSONBValue(dst interface{}, src interface{}) error {
 	v := JSONB{dst}
 	return v.Scan(src)
 }
@@ -214,7 +214,19 @@ type scannerValuer interface {
 	sql.Scanner
 }
 
+type valueWrapper interface {
+	WrapValue(src interface{}) interface{}
+}
+
+type JSONBConverter struct {
+}
+
+func (jc *JSONBConverter) WrapValue(src interface{}) interface{} {
+	return &JSONB{src}
+}
+
 var (
+	_ valueWrapper  = &JSONBConverter{}
 	_ scannerValuer = &StringArray{}
 	_ scannerValuer = &Int64Array{}
 	_ scannerValuer = &Float64Array{}

--- a/postgresql/custom_types_test.go
+++ b/postgresql/custom_types_test.go
@@ -12,10 +12,10 @@ type testStruct struct {
 	V JSONB  `json:"v"`
 }
 
-func TestDecodeJSONB(t *testing.T) {
+func TestFromJSONBValue(t *testing.T) {
 	{
 		a := testStruct{}
-		err := DecodeJSONB(&a, []byte(`{"x": 5, "z": "Hello", "v": 1}`))
+		err := FromJSONBValue(&a, []byte(`{"x": 5, "z": "Hello", "v": 1}`))
 		assert.NoError(t, err)
 		assert.Equal(t, "Hello", a.Z)
 		assert.Equal(t, float64(1), a.V.V)
@@ -23,7 +23,7 @@ func TestDecodeJSONB(t *testing.T) {
 	}
 	{
 		a := testStruct{}
-		err := DecodeJSONB(&a, []byte(`{"x": 5, "z": "Hello", "v": null}`))
+		err := FromJSONBValue(&a, []byte(`{"x": 5, "z": "Hello", "v": null}`))
 		assert.NoError(t, err)
 		assert.Equal(t, "Hello", a.Z)
 		assert.Equal(t, nil, a.V.V)
@@ -31,7 +31,7 @@ func TestDecodeJSONB(t *testing.T) {
 	}
 	{
 		a := testStruct{}
-		err := DecodeJSONB(&a, []byte(`{"x": 5, "z": "Hello"}`))
+		err := FromJSONBValue(&a, []byte(`{"x": 5, "z": "Hello"}`))
 		assert.NoError(t, err)
 		assert.Equal(t, "Hello", a.Z)
 		assert.Equal(t, nil, a.V.V)
@@ -39,19 +39,19 @@ func TestDecodeJSONB(t *testing.T) {
 	}
 	{
 		a := testStruct{}
-		err := DecodeJSONB(&a, []byte(`{"v": "Hello"}`))
+		err := FromJSONBValue(&a, []byte(`{"v": "Hello"}`))
 		assert.NoError(t, err)
 		assert.Equal(t, "Hello", a.V.V)
 	}
 	{
 		a := testStruct{}
-		err := DecodeJSONB(&a, []byte(`{"v": true}`))
+		err := FromJSONBValue(&a, []byte(`{"v": true}`))
 		assert.NoError(t, err)
 		assert.Equal(t, true, a.V.V)
 	}
 	{
 		a := testStruct{}
-		err := DecodeJSONB(&a, []byte(`{}`))
+		err := FromJSONBValue(&a, []byte(`{}`))
 		assert.NoError(t, err)
 		assert.Equal(t, nil, a.V.V)
 	}

--- a/postgresql/database.go
+++ b/postgresql/database.go
@@ -176,6 +176,8 @@ func (d *database) ConvertValues(values []interface{}) []interface{} {
 		case map[string]interface{}:
 			values[i] = (*JSONBMap)(&v)
 
+		case valueWrapper:
+			values[i] = v.WrapValue(values[i])
 		}
 	}
 	return values

--- a/postgresql/database.go
+++ b/postgresql/database.go
@@ -164,6 +164,21 @@ func (d *database) ConvertValues(values []interface{}) []interface{} {
 			values[i] = (*BoolArray)(v)
 		case *map[string]interface{}:
 			values[i] = (*JSONBMap)(v)
+		case *map[string]string:
+			*v = (map[string]string)(nil)
+			values[i] = &JSONB{v}
+		case *map[string]int64:
+			*v = (map[string]int64)(nil)
+			values[i] = &JSONB{v}
+		case *map[string]float64:
+			*v = (map[string]float64)(nil)
+			values[i] = &JSONB{v}
+		case *map[string]bool:
+			*v = (map[string]bool)(nil)
+			values[i] = &JSONB{v}
+		case *map[interface{}]interface{}:
+			*v = (map[interface{}]interface{})(nil)
+			values[i] = &JSONB{v}
 
 		case []int64:
 			values[i] = (*Int64Array)(&v)
@@ -175,6 +190,16 @@ func (d *database) ConvertValues(values []interface{}) []interface{} {
 			values[i] = (*BoolArray)(&v)
 		case map[string]interface{}:
 			values[i] = (*JSONBMap)(&v)
+		case map[string]string:
+			values[i] = JSONB{&v}
+		case map[string]int64:
+			values[i] = JSONB{&v}
+		case map[string]float64:
+			values[i] = JSONB{&v}
+		case map[string]bool:
+			values[i] = JSONB{&v}
+		case map[interface{}]interface{}:
+			values[i] = JSONB{&v}
 
 		case valueWrapper:
 			values[i] = v.WrapValue(values[i])

--- a/postgresql/database.go
+++ b/postgresql/database.go
@@ -150,6 +150,37 @@ func (d *database) clone(ctx context.Context, checkConn bool) (*database, error)
 	return clone, nil
 }
 
+func (d *database) ConvertValues(values []interface{}) []interface{} {
+	for i := range values {
+		switch v := values[i].(type) {
+
+		case *[]int64:
+			values[i] = (*Int64Array)(v)
+		case *[]string:
+			values[i] = (*StringArray)(v)
+		case *[]float64:
+			values[i] = (*Float64Array)(v)
+		case *[]bool:
+			values[i] = (*BoolArray)(v)
+		case *map[string]interface{}:
+			values[i] = (*JSONBMap)(v)
+
+		case []int64:
+			values[i] = (*Int64Array)(&v)
+		case []string:
+			values[i] = (*StringArray)(&v)
+		case []float64:
+			values[i] = (*Float64Array)(&v)
+		case []bool:
+			values[i] = (*BoolArray)(&v)
+		case map[string]interface{}:
+			values[i] = (*JSONBMap)(&v)
+
+		}
+	}
+	return values
+}
+
 // CompileStatement compiles a *exql.Statement into arguments that sql/database
 // accepts.
 func (d *database) CompileStatement(stmt *exql.Statement, args []interface{}) (string, []interface{}) {


### PR DESCRIPTION
With this change native `[]string`, `[]int64`, and `map[string]interface{}` field values will work transparently again, even on binary mode, no need for tagging them with `int64array`, `stringarray`, `jsonb`, nor providing explicit `sql.Scanner`/`driver.Valuer` methods. For other custom non-native types `sql.Scanner` and `driver.Valuer` will still be required.

See: https://github.com/upper/db/issues/391 and https://github.com/upper/db/releases/tag/v3.3.0 