### PR TITLE
Add context to query status

### DIFF
--- a/internal/sqladapter/database.go
+++ b/internal/sqladapter/database.go
@@ -369,12 +369,13 @@ func (d *database) StatementPrepare(ctx context.Context, stmt *exql.Statement) (
 	if d.Settings.LoggingEnabled() {
 		defer func(start time.Time) {
 			d.Logger().Log(&db.QueryStatus{
-				TxID:   d.txID,
-				SessID: d.sessID,
-				Query:  query,
-				Err:    err,
-				Start:  start,
-				End:    time.Now(),
+				TxID:    d.txID,
+				SessID:  d.sessID,
+				Query:   query,
+				Err:     err,
+				Start:   start,
+				End:     time.Now(),
+				Context: ctx,
 			})
 		}(time.Now())
 	}
@@ -400,13 +401,14 @@ func (d *database) StatementExec(ctx context.Context, stmt *exql.Statement, args
 		defer func(start time.Time) {
 
 			status := db.QueryStatus{
-				TxID:   d.txID,
-				SessID: d.sessID,
-				Query:  query,
-				Args:   args,
-				Err:    err,
-				Start:  start,
-				End:    time.Now(),
+				TxID:    d.txID,
+				SessID:  d.sessID,
+				Query:   query,
+				Args:    args,
+				Err:     err,
+				Start:   start,
+				End:     time.Now(),
+				Context: ctx,
 			}
 
 			if res != nil {
@@ -459,13 +461,14 @@ func (d *database) StatementQuery(ctx context.Context, stmt *exql.Statement, arg
 	if d.Settings.LoggingEnabled() {
 		defer func(start time.Time) {
 			d.Logger().Log(&db.QueryStatus{
-				TxID:   d.txID,
-				SessID: d.sessID,
-				Query:  query,
-				Args:   args,
-				Err:    err,
-				Start:  start,
-				End:    time.Now(),
+				TxID:    d.txID,
+				SessID:  d.sessID,
+				Query:   query,
+				Args:    args,
+				Err:     err,
+				Start:   start,
+				End:     time.Now(),
+				Context: ctx,
 			})
 		}(time.Now())
 	}
@@ -502,13 +505,14 @@ func (d *database) StatementQueryRow(ctx context.Context, stmt *exql.Statement, 
 	if d.Settings.LoggingEnabled() {
 		defer func(start time.Time) {
 			d.Logger().Log(&db.QueryStatus{
-				TxID:   d.txID,
-				SessID: d.sessID,
-				Query:  query,
-				Args:   args,
-				Err:    err,
-				Start:  start,
-				End:    time.Now(),
+				TxID:    d.txID,
+				SessID:  d.sessID,
+				Query:   query,
+				Args:    args,
+				Err:     err,
+				Start:   start,
+				End:     time.Now(),
+				Context: ctx,
 			})
 		}(time.Now())
 	}

--- a/logger.go
+++ b/logger.go
@@ -22,6 +22,7 @@
 package db
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"regexp"
@@ -38,6 +39,7 @@ const (
 	fmtLogLastInsertID = `Last insert ID: %d`
 	fmtLogError        = `Error:          %v`
 	fmtLogTimeTaken    = `Time taken:     %0.5fs`
+	fmtLogContext      = `Context:        %v`
 )
 
 var (
@@ -60,6 +62,8 @@ type QueryStatus struct {
 
 	Start time.Time
 	End   time.Time
+
+	Context context.Context
 }
 
 // String returns a formatted log message.
@@ -96,6 +100,10 @@ func (q *QueryStatus) String() string {
 	}
 
 	lines = append(lines, fmt.Sprintf(fmtLogTimeTaken, float64(q.End.UnixNano()-q.Start.UnixNano())/float64(1e9)))
+
+	if q.Context != nil {
+		lines = append(lines, fmt.Sprintf(fmtLogContext, q.Context))
+	}
 
 	return strings.Join(lines, "\n")
 }


### PR DESCRIPTION
With this change, current context which carries "request_id" or other useful information can be passed down to logger.

``` Log
[2017-08-13T10:45:41.256Z #65816]  INFO -- : Session ID: 00002, Query: CREATE TABLE `users` (`id` int(11) unsigned NOT NULL AUTO_INCREMENT, `name` text, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8;, Error: Error 1050: Table 'users' already exists, Time elapsed: 0.00238s request_id=0cc175b9c0f1b6a831c399e269772661
[2017-08-13T10:45:41.280Z #65816]  INFO -- : Session ID: 00002, Query: INSERT INTO `users` VALUES (), Rows affected: 1, Last insert ID: 1, Time elapsed: 0.00134s request_id=0cc175b9c0f1b6a831c399e269772661
[2017-08-13T10:45:41.282Z #65816]  INFO -- : Session ID: 00002, Query: SELECT * FROM `users` WHERE (`id` = ?), Arguments: []interface {}{1}, Time elapsed: 0.00199s request_id=0cc175b9c0f1b6a831c399e269772661
[2017-08-13T10:45:41.294Z #65816]  INFO -- : Session ID: 00002, Query: DROP TABLE `users`, Time elapsed: 0.01176s request_id=0cc175b9c0f1b6a831c399e269772661
```