### PR TITLE
Adding CockroachDB support(similar to PostgreSQL)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,10 @@ test-internal:
 
 test-libs: test-lib test-internal
 
-test-adapters: test-adapter-postgresql test-adapter-mysql test-adapter-sqlite test-adapter-mssql test-adapter-ql test-adapter-mongo
+test-adapters: test-adapter-cockroachdb test-adapter-postgresql test-adapter-mysql test-adapter-sqlite test-adapter-mssql test-adapter-ql test-adapter-mongo
 
 reset-db:
+	$(MAKE) -C cockroachdb reset-db && \
 	$(MAKE) -C postgresql reset-db && \
 	$(MAKE) -C mysql reset-db && \
 	$(MAKE) -C sqlite reset-db && \

--- a/cockroachdb/Makefile
+++ b/cockroachdb/Makefile
@@ -1,0 +1,50 @@
+SHELL := bash
+
+DB_HOST   ?= 127.0.0.1
+DB_PORT   ?= 26257
+
+DB_USERNAME ?= upperio_tests
+DB_PASSWORD ?= upperio_secret
+DB_NAME     ?= upperio_tests
+
+TEST_FLAGS ?=
+
+export DB_HOST
+export DB_NAME
+export DB_PASSWORD
+export DB_PORT
+export DB_USERNAME
+
+build:
+	go build && go install
+
+require-client:
+	@if [ -z "$$(which psql)" ]; then \
+		echo 'Missing "psql" command. Please install the PostgreSQL client and try again.' && \
+		exit 1; \
+	fi
+
+generate:
+	go generate && \
+	go get -d -t -v ./...
+
+reset-db: require-client
+	SQL="" && \
+	SQL+="DROP DATABASE IF EXISTS $(DB_NAME)_schema CASCADE;" && \
+	SQL+="DROP DATABASE IF EXISTS $(DB_NAME) CASCADE;" && \
+	SQL+="DROP USER IF EXISTS $(DB_USERNAME);" && \
+	SQL+="CREATE USER $(DB_USERNAME) WITH PASSWORD '$(DB_PASSWORD)';" && \
+	SQL+="CREATE DATABASE $(DB_NAME) ENCODING='UTF-8';" && \
+	SQL+="CREATE DATABASE $(DB_NAME)_schema ENCODING='UTF-8';" && \
+	SQL+="GRANT ALL ON DATABASE $(DB_NAME) TO $(DB_USERNAME);" && \
+	SQL+="GRANT ALL ON DATABASE $(DB_NAME)_schema TO $(DB_USERNAME);" && \
+	if [ ! -z "$$CI" ]; then \
+		psql -Uroot -h$(DB_HOST) -p$(DB_PORT) <<< $$SQL; \
+	else \
+		PGPASSWORD="$(DB_PASSWORD)" \
+		psql -Uroot -h$(DB_HOST) -p$(DB_PORT) <<< $$SQL; \
+	fi
+
+test: reset-db generate
+	#go test -tags generated -v -race # race: limit on 8192 simultaneously alive goroutines is exceeded, dying
+	go test -tags generated -v $(TEST_FLAGS)

--- a/cockroachdb/README.md
+++ b/cockroachdb/README.md
@@ -1,0 +1,6 @@
+# CockroachDB adapter for upper.io/db
+
+Please read the full docs, acknowledgements and examples at
+[https://upper.io/db.v3/cockroachdb][1]
+
+[1]: https://upper.io/db.v3/cockroachdb

--- a/cockroachdb/adapter_test.go
+++ b/cockroachdb/adapter_test.go
@@ -1,0 +1,1142 @@
+// Copyright (c) 2012-today The upper.io/db authors. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+//go:generate bash -c "sed s/ADAPTER/cockroachdb/g ../internal/sqladapter/testing/adapter.go.tpl > generated_test.go"
+package cockroachdb
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"fmt"
+	"math/rand"
+	"os"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
+	"upper.io/db.v3"
+	"upper.io/db.v3/lib/sqlbuilder"
+	"time"
+)
+
+const (
+	testTimeZone = "Canada/Eastern"
+)
+
+var settings = ConnectionURL{
+	Database: os.Getenv("DB_NAME"),
+	User:     os.Getenv("DB_USERNAME"),
+	Password: os.Getenv("DB_PASSWORD"),
+	Host:     os.Getenv("DB_HOST") + ":" + os.Getenv("DB_PORT"),
+	Options: map[string]string{
+		"timezone": testTimeZone,
+	},
+}
+
+func tearUp() error {
+	sess := mustOpen()
+	defer sess.Close()
+
+	batch := []string{
+		`DROP TABLE IF EXISTS artist`,
+
+		`CREATE TABLE artist (
+			id serial primary key,
+			name varchar(60)
+		)`,
+		`DROP TABLE IF EXISTS artist_x`,
+
+		`CREATE TABLE artist_x (
+			id serial primary key,
+			name varchar(60)
+		)`,
+		`DROP TABLE IF EXISTS publication`,
+
+		`CREATE TABLE publication (
+			id serial primary key,
+			title varchar(80),
+			author_id integer
+		)`,
+
+		`DROP TABLE IF EXISTS review`,
+
+		`CREATE TABLE review (
+			id serial primary key,
+			publication_id integer,
+			name varchar(80),
+			comments text,
+			created timestamp without time zone
+		)`,
+
+		`DROP TABLE IF EXISTS data_types`,
+
+		`CREATE TABLE data_types (
+			id serial primary key,
+			_uint integer,
+			_uint8 integer,
+			_uint16 integer,
+			_uint32 integer,
+			_uint64 integer,
+			_int integer,
+			_int8 integer,
+			_int16 integer,
+			_int32 integer,
+			_int64 integer,
+			_float32 numeric(10,6),
+			_float64 numeric(10,6),
+			_bool boolean,
+			_string text,
+			_date timestamp with time zone,
+			_nildate timestamp without time zone null,
+			_ptrdate timestamp without time zone,
+			_defaultdate timestamp without time zone DEFAULT now(),
+			_time bigint
+		)`,
+
+		`DROP TABLE IF EXISTS stats_test`,
+
+		`CREATE TABLE stats_test (
+			id serial primary key,
+			numeric integer,
+			value integer
+		)`,
+
+		`DROP TABLE IF EXISTS composite_keys`,
+
+		`CREATE TABLE composite_keys (
+			code varchar(255) default '',
+			user_id varchar(255) default '',
+			some_val varchar(255) default '',
+			primary key (code, user_id)
+		)`,
+
+		`DROP TABLE IF EXISTS option_types`,
+
+		`CREATE TABLE option_types (
+			id serial primary key,
+			name varchar(255) default '',
+			tags varchar(64)[]
+			--TODO ,settings jsonb
+		)`,
+
+		`DROP TABLE IF EXISTS upperio_tests_schema.test`,
+
+		//`DROP SCHEMA IF EXISTS upperio_tests_schema`, // Schema IS NOT SUPPORTED
+
+		//`CREATE SCHEMA upperio_tests_schema`, // Schema IS NOT SUPPORTED
+
+		`CREATE TABLE upperio_tests_schema.test (id integer)`,
+
+		`DROP TABLE IF EXISTS pg_types`,
+
+		`CREATE TABLE pg_types (id serial primary key
+			, uint8_value smallint
+			, uint8_value_array smallint[]
+
+			, int64_value smallint
+			, int64_value_array smallint[]
+
+			, integer_array integer[]
+			, string_array text[]
+			--TODO , jsonb_map jsonb
+
+			, integer_array_ptr integer[]
+			, string_array_ptr text[]
+			--TODO , jsonb_map_ptr jsonb
+
+			, auto_integer_array integer[]
+			, auto_string_array text[]
+			--TODO , auto_jsonb_map jsonb
+			--TODO , auto_jsonb_map_string jsonb
+			--TODO , auto_jsonb_map_integer jsonb
+
+			--TODO , jsonb_object jsonb
+			--TODO , jsonb_array jsonb
+
+			--TODO , custom_jsonb_object jsonb
+			--TODO , auto_custom_jsonb_object jsonb
+
+			--TODO , custom_jsonb_object_ptr jsonb
+			--TODO , auto_custom_jsonb_object_ptr jsonb
+
+			--TODO , custom_jsonb_object_array jsonb
+			--TODO , auto_custom_jsonb_object_array jsonb
+			--TODO , auto_custom_jsonb_object_map jsonb
+
+			, string_value varchar(255)
+			, integer_value int
+			, varchar_value varchar(64)
+			, decimal_value decimal
+
+			, integer_compat_value int
+			, uinteger_compat_value int
+			, string_compat_value text
+
+			--TODO , integer_compat_value_jsonb_array jsonb
+			--TODO , string_compat_value_jsonb_array jsonb
+			--TODO , uinteger_compat_value_jsonb_array jsonb
+
+			, string_value_ptr varchar(255)
+			, integer_value_ptr int
+			, varchar_value_ptr varchar(64)
+			, decimal_value_ptr decimal
+
+		)`,
+
+		`DROP TABLE IF EXISTS issue_370`,
+
+		`CREATE TABLE issue_370 (
+			id UUID PRIMARY KEY,
+			name VARCHAR(25)
+		)`,
+		//unimplemented: column id is of type ARRAY and thus is not indexable
+		//TODO: `DROP TABLE IF EXISTS issue_370_2`,
+
+		//TODO: `CREATE TABLE issue_370_2 (
+		//TODO:	id INTEGER[3] PRIMARY KEY,
+		//TODO:			name VARCHAR(25)
+		//TODO:)`,
+	}
+
+	for _, s := range batch {
+		driver := sess.Driver().(*sql.DB)
+		if _, err := driver.Exec(s); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+type customJSONB struct {
+	N string  `json:"name"`
+	V float64 `json:"value"`
+}
+
+func (c customJSONB) Value() (driver.Value, error) {
+	return JSONBValue(c)
+}
+
+func (c *customJSONB) Scan(src interface{}) error {
+	return ScanJSONB(c, src)
+}
+
+type autoCustomJSONB struct {
+	N string  `json:"name"`
+	V float64 `json:"value"`
+
+	*JSONBConverter
+}
+
+var (
+	_ = driver.Valuer(&customJSONB{})
+	_ = sql.Scanner(&customJSONB{})
+)
+
+type int64Compat int64
+
+type uintCompat uint
+
+type stringCompat string
+
+type uint8Compat uint8
+
+type int64CompatArray []int64Compat
+
+type uint8CompatArray []uint8Compat
+
+type uintCompatArray []uintCompat
+
+func (u *uint8Compat) Scan(src interface{}) error {
+	if src != nil {
+		switch v := src.(type) {
+		case int64:
+			*u = uint8Compat((src).(int64))
+		case []byte:
+			i, err := strconv.ParseInt(string(v), 10, 64)
+			if err != nil {
+				return err
+			}
+			*u = uint8Compat(i)
+		default:
+			panic(fmt.Sprintf("expected type %T", src))
+		}
+	}
+	return nil
+}
+
+func (u uint8CompatArray) WrapValue(src interface{}) interface{} {
+	return Array(src)
+}
+
+func (u *int64Compat) Scan(src interface{}) error {
+	if src != nil {
+		switch v := src.(type) {
+		case int64:
+			*u = int64Compat((src).(int64))
+		case []byte:
+			i, err := strconv.ParseInt(string(v), 10, 64)
+			if err != nil {
+				return err
+			}
+			*u = int64Compat(i)
+		default:
+			panic(fmt.Sprintf("expected type %T", src))
+		}
+	}
+	return nil
+}
+
+func (u int64CompatArray) WrapValue(src interface{}) interface{} {
+	return Array(src)
+}
+
+func testCockroachDBTypes(t *testing.T, sess sqlbuilder.Database) {
+
+	type PGTypeInline struct {
+		IntegerArrayPtr *Int64Array  `db:"integer_array_ptr,omitempty"`
+		StringArrayPtr  *StringArray `db:"string_array_ptr,omitempty"`
+		//TODO: JSONBMapPtr     *JSONBMap    `db:"jsonb_map_ptr,omitempty"`
+	}
+
+	type PGTypeAutoInline struct {
+		AutoIntegerArray    []int64                `db:"auto_integer_array"`
+		AutoStringArray     []string               `db:"auto_string_array"`
+		//TODO: AutoJSONBMap        map[string]interface{} `db:"auto_jsonb_map"`
+		//TODO: AutoJSONBMapString  map[string]string      `db:"auto_jsonb_map_string"`
+		//TODO: AutoJSONBMapInteger map[string]int64       `db:"auto_jsonb_map_integer"`
+	}
+
+	type PGType struct {
+		ID int64 `db:"id,omitempty"`
+
+		UInt8Value      uint8Compat      `db:"uint8_value"`
+		UInt8ValueArray uint8CompatArray `db:"uint8_value_array"`
+
+		Int64Value      int64Compat      `db:"int64_value"`
+		Int64ValueArray int64CompatArray `db:"int64_value_array"`
+
+		IntegerArray Int64Array  `db:"integer_array"`
+		StringArray  StringArray `db:"string_array,stringarray"`
+		//TODO: JSONBMap     JSONBMap    `db:"jsonb_map"`
+
+		PGTypeInline `db:",inline"`
+
+		PGTypeAutoInline `db:",inline"`
+
+		//TODO: JSONBObject JSONB      `db:"jsonb_object"`
+		//TODO: JSONBArray  JSONBArray `db:"jsonb_array"`
+
+		//TODO: CustomJSONBObject     customJSONB     `db:"custom_jsonb_object"`
+		//TODO: AutoCustomJSONBObject autoCustomJSONB `db:"auto_custom_jsonb_object"`
+
+		//TODO: CustomJSONBObjectPtr     *customJSONB     `db:"custom_jsonb_object_ptr,omitempty"`
+		//TODO: AutoCustomJSONBObjectPtr *autoCustomJSONB `db:"auto_custom_jsonb_object_ptr,omitempty"`
+
+		//TODO: AutoCustomJSONBObjectArray []autoCustomJSONB          `db:"auto_custom_jsonb_object_array"`
+		//TODO: AutoCustomJSONBObjectMap   map[string]autoCustomJSONB `db:"auto_custom_jsonb_object_map"`
+
+		StringValue  string  `db:"string_value"`
+		IntegerValue int64   `db:"integer_value"`
+		VarcharValue string  `db:"varchar_value"`
+		DecimalValue float64 `db:"decimal_value"`
+
+		Int64CompatValue  int64Compat  `db:"integer_compat_value"`
+		UIntCompatValue   uintCompat   `db:"uinteger_compat_value"`
+		StringCompatValue stringCompat `db:"string_compat_value"`
+
+		//TODO: Int64CompatValueJSONBArray  []int64Compat   `db:"integer_compat_value_jsonb_array"`
+		//TODO:UIntCompatValueJSONBArray   uintCompatArray `db:"uinteger_compat_value_jsonb_array"`
+		//TODO:StringCompatValueJSONBArray []stringCompat  `db:"string_compat_value_jsonb_array"`
+
+		StringValuePtr  *string  `db:"string_value_ptr,omitempty"`
+		IntegerValuePtr *int64   `db:"integer_value_ptr,omitempty"`
+		VarcharValuePtr *string  `db:"varchar_value_ptr,omitempty"`
+		DecimalValuePtr *float64 `db:"decimal_value_ptr,omitempty"`
+	}
+
+	integerValue := int64(10)
+	stringValue := string("ten")
+	decimalValue := float64(10.0)
+
+	integerArrayValue := Int64Array{1, 2, 3, 4}
+	stringArrayValue := StringArray{"a", "b", "c"}
+	//TODO: jsonbMapValue := JSONBMap{"Hello": "World"}
+
+	testValue := "Hello world!"
+
+	origPgTypeTests := []PGType{
+		PGType{
+			UInt8Value:      7,
+			UInt8ValueArray: uint8CompatArray{1, 2, 3, 4, 5, 6},
+		},
+		PGType{
+			Int64Value:      -1,
+			Int64ValueArray: int64CompatArray{1, 2, 3, -4, 5, 6},
+		},
+		PGType{
+			UInt8Value:      1,
+			UInt8ValueArray: uint8CompatArray{1, 2, 3, 4, 5, 6},
+		},
+		PGType{
+			Int64Value:      1,
+			Int64ValueArray: int64CompatArray{7, 7, 7},
+		},
+		PGType{
+			Int64Value:      1,
+			Int64ValueArray: int64CompatArray{},
+		},
+		PGType{
+			Int64Value:      99,
+			Int64ValueArray: nil,
+		},
+		PGType{
+			Int64CompatValue:  -5,
+			UIntCompatValue:   3,
+			StringCompatValue: "abc",
+		},
+		/*TODO PGType{
+			Int64CompatValueJSONBArray:  []int64Compat{1, -2, 3, -4},
+			UIntCompatValueJSONBArray:   []uintCompat{1, 2, 3, 4},
+			StringCompatValueJSONBArray: []stringCompat{"a", "b", "", "c"},
+		},
+		PGType{
+			Int64CompatValueJSONBArray:  []int64Compat(nil),
+			UIntCompatValueJSONBArray:   []uintCompat(nil),
+			StringCompatValueJSONBArray: []stringCompat(nil),
+		},*/
+		PGType{
+			IntegerValuePtr: &integerValue,
+			StringValuePtr:  &stringValue,
+			DecimalValuePtr: &decimalValue,
+			//TODO: PGTypeAutoInline: PGTypeAutoInline{
+			//TODO: 	AutoJSONBMapString:  map[string]string{"a": "x", "b": "67"},
+			//TODO: 	AutoJSONBMapInteger: map[string]int64{"a": 12, "b": 13},
+			//TODO: },
+		},
+		PGType{
+			IntegerValue: integerValue,
+			StringValue:  stringValue,
+			DecimalValue: decimalValue,
+		},
+		PGType{
+			IntegerArray: []int64{1, 2, 3, 4},
+		},
+		PGType{
+			PGTypeAutoInline: PGTypeAutoInline{
+				AutoIntegerArray: Int64Array{1, 2, 3, 4},
+				AutoStringArray:  nil,
+			},
+		},
+		/* TODO: PGType{
+			AutoCustomJSONBObjectArray: []autoCustomJSONB{
+				autoCustomJSONB{
+					N: "Hello",
+				},
+				autoCustomJSONB{
+					N: "World",
+				},
+			},
+			AutoCustomJSONBObjectMap: map[string]autoCustomJSONB{
+				"a": autoCustomJSONB{
+					N: "Hello",
+				},
+				"b": autoCustomJSONB{
+					N: "World",
+				},
+			},
+			PGTypeAutoInline: PGTypeAutoInline{
+				AutoJSONBMap: map[string]interface{}{
+					"Hello": "world",
+					"Roses": "red",
+				},
+			},
+			JSONBArray: JSONBArray{float64(1), float64(2), float64(3), float64(4)},
+		},*/
+		PGType{
+			PGTypeAutoInline: PGTypeAutoInline{
+				AutoIntegerArray: nil,
+			},
+		},
+		/* TODO: PGType{
+			PGTypeAutoInline: PGTypeAutoInline{
+				AutoJSONBMap: map[string]interface{}{},
+			},
+			JSONBArray: JSONBArray{},
+		},
+		PGType{
+			PGTypeAutoInline: PGTypeAutoInline{
+				AutoJSONBMap: map[string]interface{}(nil),
+			},
+			JSONBArray: JSONBArray(nil),
+		},*/
+		PGType{
+			PGTypeAutoInline: PGTypeAutoInline{
+				AutoStringArray: []string{"aaa", "bbb", "ccc"},
+			},
+		},
+		PGType{
+			PGTypeAutoInline: PGTypeAutoInline{
+				AutoStringArray: nil,
+			},
+		},
+		/* TODO: PGType{
+			PGTypeAutoInline: PGTypeAutoInline{
+				AutoJSONBMap: map[string]interface{}{"hello": "world!"},
+			},
+		},*/
+		PGType{
+			IntegerArray: []int64{1, 2, 3, 4},
+			StringArray:  []string{"a", "boo", "bar"},
+		},
+		PGType{
+			StringValue:  stringValue,
+			DecimalValue: decimalValue,
+		},
+		PGType{
+			IntegerArray: []int64{},
+		},
+		PGType{
+			StringArray: []string{},
+		},
+		PGType{
+			IntegerArray: []int64{},
+			StringArray:  []string{},
+		},
+		PGType{},
+		PGType{
+			IntegerArray: []int64{1},
+			StringArray:  []string{"a"},
+		},
+		PGType{
+			PGTypeInline: PGTypeInline{
+				IntegerArrayPtr: &integerArrayValue,
+				StringArrayPtr:  &stringArrayValue,
+				//TODO JSONBMapPtr:     &jsonbMapValue,
+			},
+		},
+		PGType{
+			IntegerArray: []int64{0, 0, 0, 0},
+			StringValue:  testValue,
+			/* TODO: CustomJSONBObject: customJSONB{
+				N: "Hello",
+			},
+			AutoCustomJSONBObject: autoCustomJSONB{
+				N: "World",
+			},*/
+			StringArray: []string{"", "", "", ``, `""`},
+		},
+		/* TODO: PGType{
+			CustomJSONBObject:     customJSONB{},
+			AutoCustomJSONBObject: autoCustomJSONB{},
+		},
+		PGType{
+			CustomJSONBObject: customJSONB{
+				N: "Hello 1",
+			},
+			AutoCustomJSONBObject: autoCustomJSONB{
+				N: "World 2",
+			},
+		},
+		PGType{
+			CustomJSONBObjectPtr:     nil,
+			AutoCustomJSONBObjectPtr: nil,
+		},
+		PGType{
+			CustomJSONBObjectPtr:     &customJSONB{},
+			AutoCustomJSONBObjectPtr: &autoCustomJSONB{},
+		},
+		PGType{
+			CustomJSONBObjectPtr: &customJSONB{
+				N: "Hello 3",
+			},
+			AutoCustomJSONBObjectPtr: &autoCustomJSONB{
+				N: "World 4",
+			},
+		},*/
+		PGType{
+			StringValue: testValue,
+		},
+		PGType{
+			IntegerValue:    integerValue,
+			IntegerValuePtr: &integerValue,
+			/* TODO: CustomJSONBObject: customJSONB{
+				V: 4.4,
+			},*/
+		},
+		PGType{
+			StringArray: []string{"a", "boo", "bar"},
+		},
+		PGType{
+			StringArray:       []string{"a", "boo", "bar", `""`},
+			/* TODO: CustomJSONBObject: customJSONB{},*/
+		},
+		PGType{
+			IntegerArray: []int64{0},
+			StringArray:  []string{""},
+		},
+		/* TODO: PGType{
+			CustomJSONBObject: customJSONB{
+				N: "Peter",
+				V: 5.56,
+			},
+		},*/
+	}
+
+	for i := 0; i < 100; i++ {
+
+		pgTypeTests := make([]PGType, len(origPgTypeTests))
+		perm := rand.Perm(len(origPgTypeTests))
+		for i, v := range perm {
+			pgTypeTests[v] = origPgTypeTests[i]
+		}
+
+		for i := range pgTypeTests {
+			id, err := sess.Collection("pg_types").Insert(pgTypeTests[i])
+			assert.NoError(t, err)
+
+			var actual PGType
+			err = sess.Collection("pg_types").Find(id).One(&actual)
+			assert.NoError(t, err)
+
+			expected := pgTypeTests[i]
+			expected.ID = id.(int64)
+			assert.Equal(t, expected, actual)
+		}
+
+		for i := range pgTypeTests {
+			row, err := sess.InsertInto("pg_types").Values(pgTypeTests[i]).Returning("id").QueryRow()
+			assert.NoError(t, err)
+
+			var id int64
+			err = row.Scan(&id)
+			assert.NoError(t, err)
+
+			var actual PGType
+			err = sess.Collection("pg_types").Find(id).One(&actual)
+			assert.NoError(t, err)
+
+			expected := pgTypeTests[i]
+			expected.ID = id
+
+			assert.Equal(t, expected, actual)
+
+			var actual2 PGType
+			err = sess.SelectFrom("pg_types").Where("id = ?", id).One(&actual2)
+			assert.NoError(t, err)
+			assert.Equal(t, expected, actual2)
+		}
+
+		inserter := sess.InsertInto("pg_types")
+		for i := range pgTypeTests {
+			inserter = inserter.Values(pgTypeTests[i])
+		}
+		_, err := inserter.Exec()
+		assert.NoError(t, err)
+
+		err = sess.Collection("pg_types").Truncate()
+		assert.NoError(t, err)
+
+		batch := sess.InsertInto("pg_types").Batch(50)
+		go func() {
+			defer batch.Done()
+			for i := range pgTypeTests {
+				batch.Values(pgTypeTests[i])
+			}
+		}()
+
+		err = batch.Wait()
+		assert.NoError(t, err)
+
+		var values []PGType
+		err = sess.SelectFrom("pg_types").All(&values)
+		assert.NoError(t, err)
+
+		for i := range values {
+			expected := pgTypeTests[i]
+			expected.ID = values[i].ID
+			assert.Equal(t, expected, values[i])
+		}
+	}
+}
+
+func TestOptionTypes(t *testing.T) {
+	sess := mustOpen()
+	defer sess.Close()
+
+	optionTypes := sess.Collection("option_types")
+	err := optionTypes.Truncate()
+	assert.NoError(t, err)
+
+	// TODO: lets do some benchmarking on these auto-wrapped option types..
+
+	// TODO: add nullable jsonb field mapped to a []string
+
+	// A struct with wrapped option types defined in the struct tags
+	// for postgres string array and jsonb types
+	type optionType struct {
+		ID       int64                  `db:"id,omitempty"`
+		Name     string                 `db:"name"`
+		Tags     []string               `db:"tags"`
+		//TODO Settings map[string]interface{} `db:"settings"`
+	}
+
+	// Item 1
+	item1 := optionType{
+		Name:     "Food",
+		Tags:     []string{"toronto", "pizza"},
+		//TODO Settings: map[string]interface{}{"a": 1, "b": 2},
+	}
+
+	id, err := optionTypes.Insert(item1)
+	assert.NoError(t, err)
+
+	if pk, ok := id.(int64); !ok || pk == 0 {
+		t.Fatalf("Expecting an ID.")
+	}
+
+	var item1Chk optionType
+	err = optionTypes.Find(db.Cond{"id": id}).One(&item1Chk)
+	assert.NoError(t, err)
+
+	//TODO: assert.Equal(t, float64(1), item1Chk.Settings["a"])
+	assert.Equal(t, "toronto", item1Chk.Tags[0])
+
+	// Item 1 B
+	item1b := &optionType{
+		Name:     "Golang",
+		Tags:     []string{"love", "it"},
+		//TODO: Settings: map[string]interface{}{"go": 1, "lang": 2},
+	}
+
+	id, err = optionTypes.Insert(item1b)
+	assert.NoError(t, err)
+
+	if pk, ok := id.(int64); !ok || pk == 0 {
+		t.Fatalf("Expecting an ID.")
+	}
+
+	var item1bChk optionType
+	err = optionTypes.Find(db.Cond{"id": id}).One(&item1bChk)
+	assert.NoError(t, err)
+
+	//TODO: assert.Equal(t, float64(1), item1bChk.Settings["go"])
+	assert.Equal(t, "love", item1bChk.Tags[0])
+
+	// Item 1 C
+	item1c := &optionType{
+		Name: "Sup", Tags: []string{}, //TODO: Settings: map[string]interface{}{},
+	}
+
+	id, err = optionTypes.Insert(item1c)
+	assert.NoError(t, err)
+
+	if pk, ok := id.(int64); !ok || pk == 0 {
+		t.Fatalf("Expecting an ID.")
+	}
+
+	var item1cChk optionType
+	err = optionTypes.Find(db.Cond{"id": id}).One(&item1cChk)
+	assert.NoError(t, err)
+
+	assert.Zero(t, len(item1cChk.Tags))
+	//TODO: assert.Zero(t, len(item1cChk.Settings))
+
+	// An option type to pointer jsonb field
+	type optionType2 struct {
+		ID       int64       `db:"id,omitempty"`
+		Name     string      `db:"name"`
+		Tags     StringArray `db:"tags"`
+		//TODO: Settings *JSONBMap   `db:"settings"`
+	}
+
+	item2 := optionType2{
+		Name: "JS", Tags: []string{"hi", "bye"}, //TODO: Settings: nil,
+	}
+
+	id, err = optionTypes.Insert(item2)
+	assert.NoError(t, err)
+
+	if pk, ok := id.(int64); !ok || pk == 0 {
+		t.Fatalf("Expecting an ID.")
+	}
+
+	var item2Chk optionType2
+	res := optionTypes.Find(db.Cond{"id": id})
+	err = res.One(&item2Chk)
+	assert.NoError(t, err)
+
+	assert.Equal(t, id.(int64), item2Chk.ID)
+
+	assert.Equal(t, item2Chk.Name, item2.Name)
+
+	assert.Equal(t, item2Chk.Tags[0], item2.Tags[0])
+	assert.Equal(t, len(item2Chk.Tags), len(item2.Tags))
+
+	// Update the value
+	m := JSONBMap{}
+	m["lang"] = "javascript"
+	m["num"] = 31337
+	//TODO: item2.Settings = &m
+	err = res.Update(item2)
+	assert.NoError(t, err)
+
+	err = res.One(&item2Chk)
+	assert.NoError(t, err)
+
+	//TODO: assert.Equal(t, float64(31337), (*item2Chk.Settings)["num"].(float64))
+
+	//TODO: assert.Equal(t, "javascript", (*item2Chk.Settings)["lang"])
+
+	// An option type to pointer string array field
+	type optionType3 struct {
+		ID       int64        `db:"id,omitempty"`
+		Name     string       `db:"name"`
+		Tags     *StringArray `db:"tags"`
+		//TODO: Settings JSONBMap     `db:"settings"`
+	}
+
+	item3 := optionType3{
+		Name:     "Julia",
+		Tags:     nil,
+		//TODO: Settings: JSONBMap{"girl": true, "lang": true},
+	}
+
+	id, err = optionTypes.Insert(item3)
+	assert.NoError(t, err)
+
+	if pk, ok := id.(int64); !ok || pk == 0 {
+		t.Fatalf("Expecting an ID.")
+	}
+
+	var item3Chk optionType2
+	err = optionTypes.Find(db.Cond{"id": id}).One(&item3Chk)
+	assert.NoError(t, err)
+}
+
+type Settings struct {
+	Name string `json:"name"`
+	Num  int64  `json:"num"`
+}
+
+func (s *Settings) Scan(src interface{}) error {
+	return ScanJSONB(s, src)
+}
+func (s Settings) Value() (driver.Value, error) {
+	return JSONBValue(s)
+}
+
+func TestOptionTypeJsonbStruct(t *testing.T) {
+	sess := mustOpen()
+	defer sess.Close()
+
+	optionTypes := sess.Collection("option_types")
+
+	err := optionTypes.Truncate()
+	assert.NoError(t, err)
+
+	type OptionType struct {
+		ID       int64       `db:"id,omitempty"`
+		Name     string      `db:"name"`
+		Tags     StringArray `db:"tags"`
+		//TODO: Settings Settings    `db:"settings"`
+	}
+
+	item1 := &OptionType{
+		Name:     "Hi",
+		Tags:     []string{"aah", "ok"},
+		//TODO: Settings: Settings{Name: "a", Num: 123},
+	}
+
+	id, err := optionTypes.Insert(item1)
+	assert.NoError(t, err)
+
+	if pk, ok := id.(int64); !ok || pk == 0 {
+		t.Fatalf("Expecting an ID.")
+	}
+
+	var item1Chk OptionType
+	err = optionTypes.Find(db.Cond{"id": id}).One(&item1Chk)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 2, len(item1Chk.Tags))
+	assert.Equal(t, "aah", item1Chk.Tags[0])
+	//TODO: assert.Equal(t, "a", item1Chk.Settings.Name)
+	//TODO: assert.Equal(t, int64(123), item1Chk.Settings.Num)
+}
+
+func TestSchemaCollection(t *testing.T) {
+	sess := mustOpen()
+	defer sess.Close()
+
+	col := sess.Collection("upperio_tests_schema.test")
+	_, err := col.Insert(map[string]int{"id": 9})
+	assert.Equal(t, nil, err)
+
+	var dump []map[string]int
+	err = col.Find().All(&dump)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(dump))
+	assert.Equal(t, 9, dump[0]["id"])
+}
+
+func TestMaxOpenConns_Issue340(t *testing.T) {
+	sess := mustOpen()
+	defer sess.Close()
+
+	sess.SetMaxOpenConns(5)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 30; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+
+			err := sess.Tx(nil, func(sess sqlbuilder.Tx) error {
+				secs,_ := strconv.Atoi(fmt.Sprintf(`1.%d`, i))
+				time.Sleep( time.Duration(secs) * time.Second)
+				return nil
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	sess.SetMaxOpenConns(0)
+}
+
+func TestUUIDInsert_Issue370(t *testing.T) {
+	sess := mustOpen()
+	defer sess.Close()
+
+	{
+		type itemT struct {
+			ID   *uuid.UUID `db:"id"`
+			Name string     `db:"name"`
+		}
+
+		newUUID := uuid.NewV4()
+
+		item1 := itemT{
+			ID:   &newUUID,
+			Name: "Jonny",
+		}
+
+		col := sess.Collection("issue_370")
+		err := col.Truncate()
+		assert.NoError(t, err)
+
+		err = col.InsertReturning(&item1)
+		assert.NoError(t, err)
+
+		var item2 itemT
+		err = col.Find(item1.ID).One(&item2)
+		assert.NoError(t, err)
+		assert.Equal(t, item1.Name, item2.Name)
+
+		var item3 itemT
+		err = col.Find(db.Cond{"id": item1.ID}).One(&item3)
+		assert.NoError(t, err)
+		assert.Equal(t, item1.Name, item3.Name)
+	}
+
+	{
+		type itemT struct {
+			ID   uuid.UUID `db:"id"`
+			Name string    `db:"name"`
+		}
+
+		item1 := itemT{
+			ID:   uuid.NewV4(),
+			Name: "Jonny",
+		}
+
+		col := sess.Collection("issue_370")
+		err := col.Truncate()
+		assert.NoError(t, err)
+
+		err = col.InsertReturning(&item1)
+		assert.NoError(t, err)
+
+		var item2 itemT
+		err = col.Find(item1.ID).One(&item2)
+		assert.NoError(t, err)
+		assert.Equal(t, item1.Name, item2.Name)
+
+		var item3 itemT
+		err = col.Find(db.Cond{"id": item1.ID}).One(&item3)
+		assert.NoError(t, err)
+		assert.Equal(t, item1.Name, item3.Name)
+	}
+	/*
+	{
+		type itemT struct {
+			ID   Int64Array `db:"id"`
+			Name string     `db:"name"`
+		}
+
+		item1 := itemT{
+			ID:   Int64Array{1, 2, 3},
+			Name: "Vojtech",
+		}
+
+
+		col := sess.Collection("issue_370_2")
+		err := col.Truncate()
+		assert.NoError(t, err)
+
+
+		err = col.InsertReturning(&item1)
+		assert.NoError(t, err)
+
+		var item2 itemT
+		err = col.Find(item1.ID).One(&item2)
+		assert.NoError(t, err)
+		assert.Equal(t, item1.Name, item2.Name)
+
+		var item3 itemT
+		err = col.Find(db.Cond{"id": item1.ID}).One(&item3)
+		assert.NoError(t, err)
+		assert.Equal(t, item1.Name, item3.Name)
+	}
+		*/
+}
+
+func TestTxOptions_Issue409(t *testing.T) {
+	sess := mustOpen()
+	defer sess.Close()
+
+	sess.SetTxOptions(sql.TxOptions{
+		ReadOnly: true,
+	})
+
+	{
+		col := sess.Collection("publication")
+
+		row := map[string]interface{}{
+			"title":     "foo",
+			"author_id": 1,
+		}
+		err := col.InsertReturning(&row)
+		assert.Error(t, err)
+
+		//TODO: assert.True(t, strings.Contains(err.Error(), "read-only transaction"))
+	}
+}
+
+func TestEscapeQuestionMark(t *testing.T) {
+	sess := mustOpen()
+	defer sess.Close()
+
+	/* TODO:
+	var val bool
+	{
+		res, err := sess.QueryRow(`SELECT '{"mykey":["val1", "val2"]}'::jsonb->'mykey' ?? ?`, "val2")
+		assert.NoError(t, err)
+
+		err = res.Scan(&val)
+		assert.NoError(t, err)
+		assert.Equal(t, true, val)
+	}
+
+	{
+		res, err := sess.QueryRow(`SELECT ?::jsonb->'mykey' ?? ?`, `{"mykey":["val1", "val2"]}`, `val2`)
+		assert.NoError(t, err)
+
+		err = res.Scan(&val)
+		assert.NoError(t, err)
+		assert.Equal(t, true, val)
+	}
+
+	{
+		res, err := sess.QueryRow(`SELECT ?::jsonb->? ?? ?`, `{"mykey":["val1", "val2"]}`, `mykey`, `val2`)
+		assert.NoError(t, err)
+
+		err = res.Scan(&val)
+		assert.NoError(t, err)
+		assert.Equal(t, true, val)
+	}*/
+}
+
+func TestTextMode_Issue391(t *testing.T) {
+	sess := mustOpen()
+	defer sess.Close()
+
+	testCockroachDBTypes(t, sess)
+}
+
+func TestBinaryMode_Issue391(t *testing.T) {
+	settingsWithBinaryMode := settings
+	settingsWithBinaryMode.Options["binary_parameters"] = "yes"
+
+	sess, err := Open(settingsWithBinaryMode)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sess.Close()
+
+	testCockroachDBTypes(t, sess)
+}
+
+func getStats(sess sqlbuilder.Database) (map[string]int, error) {
+	stats := make(map[string]int)
+
+	row := sess.Driver().(*sql.DB).QueryRow(`SELECT count(1) AS value FROM pg_prepared_statements`)
+
+	var value int
+	err := row.Scan(&value)
+	if err != nil {
+		return nil, err
+	}
+
+	stats["pg_prepared_statements_count"] = value
+
+	return stats, nil
+}
+
+func cleanUpCheck(sess sqlbuilder.Database) (err error) {
+	/*TODO var stats map[string]int
+	stats, err = getStats(sess)
+	if err != nil {
+		return err
+	}
+
+	if activeStatements := sqladapter.NumActiveStatements(); activeStatements > 128 {
+		return fmt.Errorf("Expecting active statements to be at most 128, got %d", activeStatements)
+	}*/
+
+	sess.ClearCache()
+
+	/*TODO stats, err = getStats(sess)
+	if err != nil {
+		return err
+	}
+
+	if stats["pg_prepared_statements_count"] != 0 {
+		return fmt.Errorf(`Expecting "Prepared_stmt_count" to be 0, got %d`, stats["Prepared_stmt_count"])
+	}*/
+	return nil
+}

--- a/cockroachdb/cockroachdb.go
+++ b/cockroachdb/cockroachdb.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2012-present The upper.io/db authors. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package cockroachdb // import "upper.io/db.v3/cockroachdb"
+
+import (
+	"database/sql"
+
+	"upper.io/db.v3"
+
+	"upper.io/db.v3/internal/sqladapter"
+	"upper.io/db.v3/lib/sqlbuilder"
+)
+
+const sqlDriver = `postgres`
+
+// Adapter is the unique name that you can use to refer to this adapter.
+const Adapter = `cockroachdb`
+
+func init() {
+	sqlbuilder.RegisterAdapter(Adapter, &sqlbuilder.AdapterFuncMap{
+		New:   New,
+		NewTx: NewTx,
+		Open:  Open,
+	})
+}
+
+// Open opens a new connection with the CockroachDB server. The returned session
+// is validated first by Ping and then with a test query before being returned.
+// You may call Open() just once and use it on multiple goroutines on a
+// long-running program. See https://golang.org/pkg/database/sql/#Open and
+// http://go-database-sql.org/accessing.html
+func Open(settings db.ConnectionURL) (sqlbuilder.Database, error) {
+	d := newDatabase(settings)
+	if err := d.Open(settings); err != nil {
+		return nil, err
+	}
+	return d, nil
+}
+
+// NewTx wraps a regular *sql.Tx transaction and returns a new upper-db
+// transaction backed by it.
+func NewTx(sqlTx *sql.Tx) (sqlbuilder.Tx, error) {
+	d := newDatabase(nil)
+
+	// Binding with sqladapter's logic.
+	d.BaseDatabase = sqladapter.NewBaseDatabase(d)
+
+	// Binding with sqlbuilder.
+	d.SQLBuilder = sqlbuilder.WithSession(d.BaseDatabase, template)
+
+	if err := d.BaseDatabase.BindTx(d.Context(), sqlTx); err != nil {
+		return nil, err
+	}
+
+	newTx := sqladapter.NewDatabaseTx(d)
+	return &tx{DatabaseTx: newTx}, nil
+}
+
+// New wraps a regular *sql.DB session and creates a new upper-db session
+// backed by it.
+func New(sess *sql.DB) (sqlbuilder.Database, error) {
+	d := newDatabase(nil)
+
+	// Binding with sqladapter's logic.
+	d.BaseDatabase = sqladapter.NewBaseDatabase(d)
+
+	// Binding with sqlbuilder.
+	d.SQLBuilder = sqlbuilder.WithSession(d.BaseDatabase, template)
+
+	if err := d.BaseDatabase.BindSession(sess); err != nil {
+		return nil, err
+	}
+	return d, nil
+}

--- a/cockroachdb/collection.go
+++ b/cockroachdb/collection.go
@@ -1,0 +1,100 @@
+// Copyright (c) 2012-present The upper.io/db authors. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package cockroachdb
+
+import (
+	"database/sql"
+
+	"upper.io/db.v3"
+	"upper.io/db.v3/internal/sqladapter"
+)
+
+// collection is the actual implementation of a collection.
+type collection struct {
+	sqladapter.BaseCollection // Leveraged by sqladapter
+
+	d    *database
+	name string
+}
+
+var (
+	_ = sqladapter.Collection(&collection{})
+	_ = db.Collection(&collection{})
+)
+
+// newCollection binds *collection with sqladapter.
+func newCollection(d *database, name string) *collection {
+	c := &collection{
+		name: name,
+		d:    d,
+	}
+	c.BaseCollection = sqladapter.NewBaseCollection(c)
+	return c
+}
+
+func (c *collection) Name() string {
+	return c.name
+}
+
+func (c *collection) Database() sqladapter.Database {
+	return c.d
+}
+
+// Insert inserts an item (map or struct) into the collection.
+func (c *collection) Insert(item interface{}) (interface{}, error) {
+	var err error
+
+	pKey := c.BaseCollection.PrimaryKeys()
+
+	q := c.d.InsertInto(c.Name()).Values(item)
+
+	if len(pKey) == 0 {
+		// There is no primary key.
+		var res sql.Result
+
+		if res, err = q.Exec(); err != nil {
+			return nil, err
+		}
+
+		// Attempt to use LastInsertId() (probably won't work, but the Exec()
+		// succeeded, so we can safely ignore the error from LastInsertId()).
+		lastID, _ := res.LastInsertId()
+
+		return lastID, nil
+	}
+
+	// Asking the database to return the primary key after insertion.
+	q = q.Returning(pKey...)
+
+	var keyMap db.Cond
+	if err = q.Iterator().One(&keyMap); err != nil {
+		return nil, err
+	}
+
+	// The IDSetter interface does not match, look for another interface match.
+	if len(keyMap) == 1 {
+		return keyMap[pKey[0]], nil
+	}
+
+	// This was a compound key and no interface matched it, let's return a map.
+	return keyMap, nil
+}

--- a/cockroachdb/connection.go
+++ b/cockroachdb/connection.go
@@ -1,0 +1,298 @@
+// Copyright (c) 2012-present The upper.io/db authors. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package cockroachdb
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"unicode"
+
+	"github.com/lib/pq"
+)
+
+// scanner implements a tokenizer for libpq-style option strings.
+type scanner struct {
+	s []rune
+	i int
+}
+
+// Next returns the next rune.  It returns 0, false if the end of the text has
+// been reached.
+func (s *scanner) Next() (rune, bool) {
+	if s.i >= len(s.s) {
+		return 0, false
+	}
+	r := s.s[s.i]
+	s.i++
+	return r, true
+}
+
+// SkipSpaces returns the next non-whitespace rune.  It returns 0, false if the
+// end of the text has been reached.
+func (s *scanner) SkipSpaces() (rune, bool) {
+	r, ok := s.Next()
+	for unicode.IsSpace(r) && ok {
+		r, ok = s.Next()
+	}
+	return r, ok
+}
+
+type values map[string]string
+
+func (vs values) Set(k, v string) {
+	vs[k] = v
+}
+
+func (vs values) Get(k string) (v string) {
+	return vs[k]
+}
+
+func (vs values) Isset(k string) bool {
+	_, ok := vs[k]
+	return ok
+}
+
+// A typical CockroachDB connection URL looks like:
+//
+// "postgres://bob:secret@1.2.3.4:5432/mydb?sslmode=verify-full"
+
+const connectionScheme = `postgres`
+
+// ConnectionURL represents a parsed CockroachDB connection URL.
+//
+// You can use a ConnectionURL struct as an argument for Open:
+//
+//   var settings = postgresql.ConnectionURL{
+//     Host:       "localhost",          // CockroachDB server IP or name.
+//     Database:   "peanuts",            // Database name.
+//     User:       "cbrown",             // Optional user name.
+//     Password:   "snoopy",             // Optional user password.
+//   }
+//
+//   sess, err = postgresql.Open(settings)
+//
+// If you already have a valid DSN, you can use ParseURL to convert it into
+// a ConnectionURL before passing it to Open.
+type ConnectionURL struct {
+	User     string
+	Password string
+	Host     string
+	Socket   string
+	Database string
+	Options  map[string]string
+}
+
+var escaper = strings.NewReplacer(` `, `\ `, `'`, `\'`, `\`, `\\`)
+
+// String reassembles the parsed CockroachDB connection URL into a valid DSN.
+func (c ConnectionURL) String() (s string) {
+	u := make([]string, 0, 6)
+
+	// TODO: This surely needs some sort of escaping.
+
+	if c.User != "" {
+		u = append(u, "user="+escaper.Replace(c.User))
+	}
+
+	if c.Password != "" {
+		u = append(u, "password="+escaper.Replace(c.Password))
+	}
+
+	if c.Host != "" {
+		host, port, err := net.SplitHostPort(c.Host)
+		if err == nil {
+			if host == "" {
+				host = "127.0.0.1"
+			}
+			if port == "" {
+				port = "5432"
+			}
+			u = append(u, "host="+escaper.Replace(host))
+			u = append(u, "port="+escaper.Replace(port))
+		} else {
+			u = append(u, "host="+escaper.Replace(c.Host))
+		}
+	}
+
+	if c.Socket != "" {
+		u = append(u, "host="+escaper.Replace(c.Socket))
+	}
+
+	if c.Database != "" {
+		u = append(u, "dbname="+escaper.Replace(c.Database))
+	}
+
+	// Is there actually any connection data?
+	if len(u) == 0 {
+		return ""
+	}
+
+	if c.Options == nil {
+		c.Options = map[string]string{}
+	}
+
+	// If not present, SSL mode is assumed disabled.
+	if sslMode, ok := c.Options["sslmode"]; !ok || sslMode == "" {
+		c.Options["sslmode"] = "disable"
+	}
+
+	for k, v := range c.Options {
+		u = append(u, escaper.Replace(k)+"="+escaper.Replace(v))
+	}
+
+	return strings.Join(u, " ")
+}
+
+// ParseURL parses the given DSN into a ConnectionURL struct.
+// A typical cockroachdb connection URL looks like:
+//
+//   postgres://bob:secret@1.2.3.4:26257/mydb?sslmode=verify-full
+func ParseURL(s string) (u ConnectionURL, err error) {
+	o := make(values)
+
+	if strings.HasPrefix(s, "cockroachdb://") {
+		s, err = pq.ParseURL(strings.Replace(s,"cockroachdb","postgres",1))
+		if err != nil {
+			return u, err
+		}
+	}
+
+	if err := parseOpts(s, o); err != nil {
+		return u, err
+	}
+
+	u.User = o.Get("user")
+	u.Password = o.Get("password")
+
+	h := o.Get("host")
+	p := o.Get("port")
+
+	if strings.HasPrefix(h, "/") {
+		u.Socket = h
+	} else {
+		if p == "" {
+			u.Host = h
+		} else {
+			u.Host = fmt.Sprintf("%s:%s", h, p)
+		}
+	}
+
+	u.Database = o.Get("dbname")
+
+	u.Options = make(map[string]string)
+
+	for k := range o {
+		switch k {
+		case "user", "password", "host", "port", "dbname":
+			// Skip
+		default:
+			u.Options[k] = o[k]
+		}
+	}
+
+	return u, err
+}
+
+// parseOpts parses the options from name and adds them to the values.
+//
+// The parsing code is based on conninfo_parse from libpq's fe-connect.c
+func parseOpts(name string, o values) error {
+	s := newScanner(name)
+
+	for {
+		var (
+			keyRunes, valRunes []rune
+			r                  rune
+			ok                 bool
+		)
+
+		if r, ok = s.SkipSpaces(); !ok {
+			break
+		}
+
+		// Scan the key
+		for !unicode.IsSpace(r) && r != '=' {
+			keyRunes = append(keyRunes, r)
+			if r, ok = s.Next(); !ok {
+				break
+			}
+		}
+
+		// Skip any whitespace if we're not at the = yet
+		if r != '=' {
+			r, ok = s.SkipSpaces()
+		}
+
+		// The current character should be =
+		if r != '=' || !ok {
+			return fmt.Errorf(`missing "=" after %q in connection info string"`, string(keyRunes))
+		}
+
+		// Skip any whitespace after the =
+		if r, ok = s.SkipSpaces(); !ok {
+			// If we reach the end here, the last value is just an empty string as per libpq.
+			o.Set(string(keyRunes), "")
+			break
+		}
+
+		if r != '\'' {
+			for !unicode.IsSpace(r) {
+				if r == '\\' {
+					if r, ok = s.Next(); !ok {
+						return fmt.Errorf(`missing character after backslash`)
+					}
+				}
+				valRunes = append(valRunes, r)
+
+				if r, ok = s.Next(); !ok {
+					break
+				}
+			}
+		} else {
+		quote:
+			for {
+				if r, ok = s.Next(); !ok {
+					return fmt.Errorf(`unterminated quoted string literal in connection string`)
+				}
+				switch r {
+				case '\'':
+					break quote
+				case '\\':
+					r, _ = s.Next()
+					fallthrough
+				default:
+					valRunes = append(valRunes, r)
+				}
+			}
+		}
+
+		o.Set(string(keyRunes), string(valRunes))
+	}
+
+	return nil
+}
+
+// newScanner returns a new scanner initialized with the option string s.
+func newScanner(s string) *scanner {
+	return &scanner{[]rune(s), 0}
+}

--- a/cockroachdb/connection_test.go
+++ b/cockroachdb/connection_test.go
@@ -1,0 +1,206 @@
+// Copyright (c) 2012-present The upper.io/db authors. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package cockroachdb
+
+import "testing"
+
+func TestConnectionURL(t *testing.T) {
+	c := ConnectionURL{}
+
+	// Default connection string is empty.
+	if c.String() != "" {
+		t.Fatal(`Expecting default connectiong string to be empty, got:`, c.String())
+	}
+
+	// Adding a host with port.
+	c.Host = "localhost:1234"
+
+	if c.String() != "host=localhost port=1234 sslmode=disable" {
+		t.Fatal(`Test failed, got:`, c.String())
+	}
+
+	// Adding a host.
+	c.Host = "localhost"
+
+	if c.String() != "host=localhost sslmode=disable" {
+		t.Fatal(`Test failed, got:`, c.String())
+	}
+
+	// Adding a username.
+	c.User = "Anakin"
+
+	if c.String() != "user=Anakin host=localhost sslmode=disable" {
+		t.Fatal(`Test failed, got:`, c.String())
+	}
+
+	// Adding a password with special characters.
+	c.Password = "Some Sort of ' Password"
+
+	if c.String() != `user=Anakin password=Some\ Sort\ of\ \'\ Password host=localhost sslmode=disable` {
+		t.Fatal(`Test failed, got:`, c.String())
+	}
+
+	// Adding a port.
+	c.Host = "localhost:1234"
+
+	if c.String() != `user=Anakin password=Some\ Sort\ of\ \'\ Password host=localhost port=1234 sslmode=disable` {
+		t.Fatal(`Test failed, got:`, c.String())
+	}
+
+	// Adding a database.
+	c.Database = "MyDatabase"
+
+	if c.String() != `user=Anakin password=Some\ Sort\ of\ \'\ Password host=localhost port=1234 dbname=MyDatabase sslmode=disable` {
+		t.Fatal(`Test failed, got:`, c.String())
+	}
+
+	// Adding options.
+	c.Options = map[string]string{
+		"sslmode": "verify-full",
+	}
+
+	if c.String() != `user=Anakin password=Some\ Sort\ of\ \'\ Password host=localhost port=1234 dbname=MyDatabase sslmode=verify-full` {
+		t.Fatal(`Test failed, got:`, c.String())
+	}
+}
+
+func TestParseConnectionURL(t *testing.T) {
+	var u ConnectionURL
+	var s string
+	var err error
+
+	s = "cockroachdb://anakin:skywalker@localhost/jedis"
+
+	if u, err = ParseURL(s); err != nil {
+		t.Fatal(err)
+	}
+
+	if u.User != "anakin" {
+		t.Fatal("Failed to parse username.")
+	}
+
+	if u.Password != "skywalker" {
+		t.Fatal("Failed to parse password.")
+	}
+
+	if u.Host != "localhost" {
+		t.Fatal("Failed to parse hostname.")
+	}
+
+	if u.Database != "jedis" {
+		t.Fatal("Failed to parse database.")
+	}
+
+	if u.Options["sslmode"] != "" {
+		t.Fatal("Failed to parse SSLMode.")
+	}
+
+	// case with port
+	s = "cockroachdb://anakin:skywalker@localhost:1234/jedis"
+	if u, err = ParseURL(s); err != nil {
+		t.Fatal(err)
+	}
+
+	if u.User != "anakin" {
+		t.Fatal("Failed to parse username.")
+	}
+
+	if u.Password != "skywalker" {
+		t.Fatal("Failed to parse password.")
+	}
+
+	if u.Host != "localhost:1234" {
+		t.Fatal("Failed to parse hostname.")
+	}
+
+	if u.Database != "jedis" {
+		t.Fatal("Failed to parse database.")
+	}
+
+	if u.Options["sslmode"] != "" {
+		t.Fatal("Failed to parse SSLMode.")
+	}
+
+	s = "cockroachdb://anakin:skywalker@localhost/jedis?sslmode=verify-full"
+
+	if u, err = ParseURL(s); err != nil {
+		t.Fatal(err)
+	}
+
+	if u.Options["sslmode"] != "verify-full" {
+		t.Fatal("Failed to parse SSLMode.")
+	}
+
+	s = "user=anakin password=skywalker host=localhost dbname=jedis"
+
+	if u, err = ParseURL(s); err != nil {
+		t.Fatal(err)
+	}
+
+	if u.User != "anakin" {
+		t.Fatal("Failed to parse username.")
+	}
+
+	if u.Password != "skywalker" {
+		t.Fatal("Failed to parse password.")
+	}
+
+	if u.Host != "localhost" {
+		t.Fatal("Failed to parse hostname.")
+	}
+
+	if u.Database != "jedis" {
+		t.Fatal("Failed to parse database.")
+	}
+
+	if u.Options["sslmode"] != "" {
+		t.Fatal("Failed to parse SSLMode.")
+	}
+
+	s = "user=anakin password=skywalker host=localhost dbname=jedis sslmode=verify-full"
+
+	if u, err = ParseURL(s); err != nil {
+		t.Fatal(err)
+	}
+
+	if u.Options["sslmode"] != "verify-full" {
+		t.Fatal("Failed to parse SSLMode.")
+	}
+
+	s = "user=anakin password=skywalker host=localhost dbname=jedis sslmode=verify-full timezone=UTC"
+
+	if u, err = ParseURL(s); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(u.Options) != 2 {
+		t.Fatal("Expecting exactly two options.")
+	}
+
+	if u.Options["sslmode"] != "verify-full" {
+		t.Fatal("Failed to parse SSLMode.")
+	}
+
+	if u.Options["timezone"] != "UTC" {
+		t.Fatal("Failed to parse timezone.")
+	}
+}

--- a/cockroachdb/custom_types.go
+++ b/cockroachdb/custom_types.go
@@ -1,0 +1,328 @@
+// Copyright (c) 2012-present The upper.io/db authors. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package cockroachdb
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"errors"
+	"reflect"
+
+	"github.com/lib/pq"
+	"upper.io/db.v3/lib/sqlbuilder"
+)
+
+// Array returns a sqlbuilder.ScannerValuer for any given slice. Slice elements
+// may require their own sqlbuilder.ScannerValuer.
+func Array(in interface{}) sqlbuilder.ScannerValuer {
+	return pq.Array(in)
+}
+
+// JSONB represents a CockroachDB's JSONB value:
+// https://www.postgresql.org/docs/9.6/static/datatype-json.html. JSONB
+// satisfies sqlbuilder.ScannerValuer.
+type JSONB struct {
+	V interface{}
+}
+
+// MarshalJSON encodes the wrapper value as JSON.
+func (j JSONB) MarshalJSON() ([]byte, error) {
+	return json.Marshal(j.V)
+}
+
+// UnmarshalJSON decodes the given JSON into the wrapped value.
+func (j *JSONB) UnmarshalJSON(b []byte) error {
+	var v interface{}
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	j.V = v
+	return nil
+}
+
+// Scan satisfies the sql.Scanner interface.
+func (j *JSONB) Scan(src interface{}) error {
+	if src == nil {
+		j.V = nil
+		return nil
+	}
+
+	b, ok := src.([]byte)
+	if !ok {
+		return errors.New("Scan source was not []bytes")
+	}
+
+	if err := json.Unmarshal(b, &j.V); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Value satisfies the driver.Valuer interface.
+func (j JSONB) Value() (driver.Value, error) {
+	// See https://github.com/lib/pq/issues/528#issuecomment-257197239 on why are
+	// we returning string instead of []byte.
+	if j.V == nil {
+		return nil, nil
+	}
+	if v, ok := j.V.(json.RawMessage); ok {
+		return string(v), nil
+	}
+	b, err := json.Marshal(j.V)
+	if err != nil {
+		return nil, err
+	}
+	return string(b), nil
+}
+
+// StringArray represents a one-dimensional array of strings (`[]string{}`)
+// that is compatible with CockroachDB's text array (`text[]`). StringArray
+// satisfies sqlbuilder.ScannerValuer.
+type StringArray pq.StringArray
+
+// Value satisfies the driver.Valuer interface.
+func (a StringArray) Value() (driver.Value, error) {
+	return pq.StringArray(a).Value()
+}
+
+// Scan satisfies the sql.Scanner interface.
+func (a *StringArray) Scan(src interface{}) error {
+	s := pq.StringArray(*a)
+	if err := s.Scan(src); err != nil {
+		return err
+	}
+	*a = StringArray(s)
+	return nil
+}
+
+// Int64Array represents a one-dimensional array of int64s (`[]int64{}`) that
+// is compatible with CockroachDB's integer array (`integer[]`). Int64Array
+// satisfies sqlbuilder.ScannerValuer.
+type Int64Array pq.Int64Array
+
+// Value satisfies the driver.Valuer interface.
+func (i Int64Array) Value() (driver.Value, error) {
+	return pq.Int64Array(i).Value()
+}
+
+// Scan satisfies the sql.Scanner interface.
+func (i *Int64Array) Scan(src interface{}) error {
+	s := pq.Int64Array(*i)
+	if err := s.Scan(src); err != nil {
+		return err
+	}
+	*i = Int64Array(s)
+	return nil
+}
+
+// Float64Array represents a one-dimensional array of float64s (`[]float64{}`)
+// that is compatible with CockroachDB's double precision array (`double
+// precision[]`). Float64Array satisfies sqlbuilder.ScannerValuer.
+type Float64Array pq.Float64Array
+
+// Value satisfies the driver.Valuer interface.
+func (f Float64Array) Value() (driver.Value, error) {
+	return pq.Float64Array(f).Value()
+}
+
+// Scan satisfies the sql.Scanner interface.
+func (f *Float64Array) Scan(src interface{}) error {
+	s := pq.Float64Array(*f)
+	if err := s.Scan(src); err != nil {
+		return err
+	}
+	*f = Float64Array(s)
+	return nil
+}
+
+// BoolArray represents a one-dimensional array of int64s (`[]bool{}`) that
+// is compatible with CockroachDB's boolean type (`boolean[]`). BoolArray
+// satisfies sqlbuilder.ScannerValuer.
+type BoolArray pq.BoolArray
+
+// Value satisfies the driver.Valuer interface.
+func (b BoolArray) Value() (driver.Value, error) {
+	return pq.BoolArray(b).Value()
+}
+
+// Scan satisfies the sql.Scanner interface.
+func (b *BoolArray) Scan(src interface{}) error {
+	s := pq.BoolArray(*b)
+	if err := s.Scan(src); err != nil {
+		return err
+	}
+	*b = BoolArray(s)
+	return nil
+}
+
+// GenericArray represents a one-dimensional array of any type
+// (`[]interface{}`) that is compatible with CockroachDB's array type.
+// GenericArray satisfies sqlbuilder.ScannerValuer and its elements may need to
+// satisfy sqlbuilder.ScannerValuer too.
+type GenericArray pq.GenericArray
+
+// Value satisfies the driver.Valuer interface.
+func (g GenericArray) Value() (driver.Value, error) {
+	return pq.GenericArray(g).Value()
+}
+
+// Scan satisfies the sql.Scanner interface.
+func (g *GenericArray) Scan(src interface{}) error {
+	s := pq.GenericArray(*g)
+	if err := s.Scan(src); err != nil {
+		return err
+	}
+	*g = GenericArray(s)
+	return nil
+}
+
+// JSONBMap represents a map of interfaces with string keys
+// (`map[string]interface{}`) that is compatible with CockroachDB's JSONB type.
+// JSONBMap satisfies sqlbuilder.ScannerValuer.
+type JSONBMap map[string]interface{}
+
+// Value satisfies the driver.Valuer interface.
+func (m JSONBMap) Value() (driver.Value, error) {
+	return JSONBValue(m)
+}
+
+// Scan satisfies the sql.Scanner interface.
+func (m *JSONBMap) Scan(src interface{}) error {
+	*m = map[string]interface{}(nil)
+	return ScanJSONB(m, src)
+}
+
+// JSONBArray represents an array of any type (`[]interface{}`) that is
+// compatible with CockroachDB's JSONB type. JSONBArray satisfies
+// sqlbuilder.ScannerValuer.
+type JSONBArray []interface{}
+
+// Value satisfies the driver.Valuer interface.
+func (a JSONBArray) Value() (driver.Value, error) {
+	return JSONBValue(a)
+}
+
+// Scan satisfies the sql.Scanner interface.
+func (a *JSONBArray) Scan(src interface{}) error {
+	return ScanJSONB(a, src)
+}
+
+// JSONBValue takes an interface and provides a driver.Value that can be
+// stored as a JSONB column.
+func JSONBValue(i interface{}) (driver.Value, error) {
+	v := JSONB{i}
+	return v.Value()
+}
+
+// ScanJSONB decodes a JSON byte stream into the passed dst value.
+func ScanJSONB(dst interface{}, src interface{}) error {
+	v := JSONB{dst}
+	return v.Scan(src)
+}
+
+// EncodeJSONB is deprecated and going to be removed. Use ScanJSONB instead.
+func EncodeJSONB(i interface{}) (driver.Value, error) {
+	return JSONBValue(i)
+}
+
+// DecodeJSONB is deprecated and going to be removed. Use JSONBValue instead.
+func DecodeJSONB(dst interface{}, src interface{}) error {
+	return ScanJSONB(dst, src)
+}
+
+// JSONBConverter provides a helper method WrapValue that satisfies
+// sqlbuilder.ValueWrapper, can be used to encode Go structs into JSONB
+// CockroachDB types and vice versa.
+//
+// Example:
+//
+//   type MyCustomStruct struct {
+//     ID int64 `db:"id" json:"id"`
+//     Name string `db:"name" json:"name"`
+//     ...
+//     postgresql.JSONBConverter
+//   }
+type JSONBConverter struct {
+}
+
+// WrapValue satisfies sqlbuilder.ValueWrapper
+func (obj *JSONBConverter) WrapValue(src interface{}) interface{} {
+	return &JSONB{src}
+}
+
+func autoWrap(elem reflect.Value, v interface{}) interface{} {
+	kind := elem.Kind()
+
+	if kind == reflect.Invalid {
+		return v
+	}
+
+	if elem.Type().Implements(sqlbuilder.ScannerType) {
+		return v
+	}
+
+	if elem.Type().Implements(sqlbuilder.ValuerType) {
+		return v
+	}
+
+	if elem.Type().Implements(sqlbuilder.ValueWrapperType) {
+		if elem.Type().Kind() == reflect.Ptr {
+			w := reflect.ValueOf(v)
+			if w.Kind() == reflect.Ptr {
+				z := reflect.Zero(w.Elem().Type())
+				w.Elem().Set(z)
+				return &JSONB{v}
+			}
+		}
+		vw := elem.Interface().(sqlbuilder.ValueWrapper)
+		return vw.WrapValue(elem.Interface())
+	}
+
+	switch kind {
+	case reflect.Ptr:
+		return autoWrap(elem.Elem(), v)
+	case reflect.Slice:
+		return &JSONB{v}
+	case reflect.Map:
+		if reflect.TypeOf(v).Kind() == reflect.Ptr {
+			w := reflect.ValueOf(v)
+			z := reflect.New(w.Elem().Type())
+			w.Elem().Set(z.Elem())
+		}
+		return &JSONB{v}
+	}
+
+	return v
+}
+
+// Type checks.
+var (
+	_ sqlbuilder.ValueWrapper = &JSONBConverter{}
+
+	_ sqlbuilder.ScannerValuer = &StringArray{}
+	_ sqlbuilder.ScannerValuer = &Int64Array{}
+	_ sqlbuilder.ScannerValuer = &Float64Array{}
+	_ sqlbuilder.ScannerValuer = &BoolArray{}
+	_ sqlbuilder.ScannerValuer = &GenericArray{}
+	_ sqlbuilder.ScannerValuer = &JSONBMap{}
+	_ sqlbuilder.ScannerValuer = &JSONBArray{}
+)

--- a/cockroachdb/custom_types_test.go
+++ b/cockroachdb/custom_types_test.go
@@ -1,0 +1,87 @@
+package cockroachdb
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type testStruct struct {
+	X int    `json:"x"`
+	Z string `json:"z"`
+	V JSONB  `json:"v"`
+}
+
+func TestScanJSONB(t *testing.T) {
+	{
+		a := testStruct{}
+		err := ScanJSONB(&a, []byte(`{"x": 5, "z": "Hello", "v": 1}`))
+		assert.NoError(t, err)
+		assert.Equal(t, "Hello", a.Z)
+		assert.Equal(t, float64(1), a.V.V)
+		assert.Equal(t, 5, a.X)
+	}
+	{
+		a := testStruct{}
+		err := DecodeJSONB(&a, []byte(`{"x": 5, "z": "Hello", "v": null}`))
+		assert.NoError(t, err)
+		assert.Equal(t, "Hello", a.Z)
+		assert.Equal(t, nil, a.V.V)
+		assert.Equal(t, 5, a.X)
+	}
+	{
+		a := testStruct{}
+		err := ScanJSONB(&a, []byte(`{"x": 5, "z": "Hello"}`))
+		assert.NoError(t, err)
+		assert.Equal(t, "Hello", a.Z)
+		assert.Equal(t, nil, a.V.V)
+		assert.Equal(t, 5, a.X)
+	}
+	{
+		a := testStruct{}
+		err := ScanJSONB(&a, []byte(`{"v": "Hello"}`))
+		assert.NoError(t, err)
+		assert.Equal(t, "Hello", a.V.V)
+	}
+	{
+		a := testStruct{}
+		err := ScanJSONB(&a, []byte(`{"v": true}`))
+		assert.NoError(t, err)
+		assert.Equal(t, true, a.V.V)
+	}
+	{
+		a := testStruct{}
+		err := ScanJSONB(&a, []byte(`{}`))
+		assert.NoError(t, err)
+		assert.Equal(t, nil, a.V.V)
+	}
+	{
+		a := []*testStruct{}
+		err := json.Unmarshal([]byte(`[{}]`), &a)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(a))
+		assert.Nil(t, a[0].V.V)
+	}
+	{
+		a := []*testStruct{}
+		err := json.Unmarshal([]byte(`[{"v": true}]`), &a)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(a))
+		assert.Equal(t, true, a[0].V.V)
+	}
+	{
+		a := []*testStruct{}
+		err := json.Unmarshal([]byte(`[{"v": null}]`), &a)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(a))
+		assert.Nil(t, a[0].V.V)
+	}
+	{
+		a := []*testStruct{}
+		err := json.Unmarshal([]byte(`[{"v": 12.34}]`), &a)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(a))
+		assert.Equal(t, 12.34, a[0].V.V)
+	}
+}

--- a/cockroachdb/database.go
+++ b/cockroachdb/database.go
@@ -1,0 +1,356 @@
+// Copyright (c) 2012-present The upper.io/db authors. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// Package cockroachdb wraps the github.com/lib/pq PostgreSQL driver. See
+// https://upper.io/db.v3/cockroachdb for documentation, particularities and
+// usage examples.
+package cockroachdb
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
+	"time"
+
+	_ "github.com/lib/pq" // PostgreSQL driver.
+	"upper.io/db.v3"
+	"upper.io/db.v3/internal/sqladapter"
+	"upper.io/db.v3/internal/sqladapter/compat"
+	"upper.io/db.v3/internal/sqladapter/exql"
+	"upper.io/db.v3/lib/sqlbuilder"
+)
+
+// database is the actual implementation of Database
+type database struct {
+	sqladapter.BaseDatabase
+
+	sqlbuilder.SQLBuilder
+
+	connURL db.ConnectionURL
+	mu      sync.Mutex
+}
+
+var (
+	_ = sqlbuilder.Database(&database{})
+	_ = sqladapter.Database(&database{})
+)
+
+// newDatabase creates a new *database session for internal use.
+func newDatabase(settings db.ConnectionURL) *database {
+	return &database{
+		connURL: settings,
+	}
+}
+
+// ConnectionURL returns this database session's connection URL, if any.
+func (d *database) ConnectionURL() db.ConnectionURL {
+	return d.connURL
+}
+
+// Open attempts to open a connection with the database server.
+func (d *database) Open(connURL db.ConnectionURL) error {
+	if connURL == nil {
+		return db.ErrMissingConnURL
+	}
+	d.connURL = connURL
+	return d.open()
+}
+
+// NewTx begins a transaction block with the given context.
+func (d *database) NewTx(ctx context.Context) (sqlbuilder.Tx, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	nTx, err := d.NewDatabaseTx(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &tx{DatabaseTx: nTx}, nil
+}
+
+// Collections returns a list of non-system tables from the database.
+func (d *database) Collections() (collections []string, err error) {
+	q := d.Select("table_name").
+		From("information_schema.tables").
+		Where("table_schema NOT IN ?", []string{"crdb_internal","information_schema","pg_catalog","system"})
+
+	iter := q.Iterator()
+	defer iter.Close()
+
+	for iter.Next() {
+		var tableName string
+		if err := iter.Scan(&tableName); err != nil {
+			return nil, err
+		}
+		collections = append(collections, tableName)
+	}
+
+	return collections, nil
+}
+
+// open attempts to establish a connection with the CockroachDB server.
+func (d *database) open() error {
+	// Binding with sqladapter's logic.
+	d.BaseDatabase = sqladapter.NewBaseDatabase(d)
+
+	// Binding with sqlbuilder.
+	d.SQLBuilder = sqlbuilder.WithSession(d.BaseDatabase, template)
+
+	connFn := func() error {
+		sess, err := sql.Open("postgres", d.ConnectionURL().String())
+		if err == nil {
+			sess.SetConnMaxLifetime(db.DefaultSettings.ConnMaxLifetime())
+			sess.SetMaxIdleConns(db.DefaultSettings.MaxIdleConns())
+			sess.SetMaxOpenConns(db.DefaultSettings.MaxOpenConns())
+			return d.BaseDatabase.BindSession(sess)
+		}
+		return err
+	}
+
+	if err := d.BaseDatabase.WaitForConnection(connFn); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Clone creates a copy of the database session on the given context.
+func (d *database) clone(ctx context.Context, checkConn bool) (*database, error) {
+	clone := newDatabase(d.connURL)
+
+	var err error
+	clone.BaseDatabase, err = d.NewClone(clone, checkConn)
+	if err != nil {
+		return nil, err
+	}
+
+	clone.SetContext(ctx)
+
+	clone.SQLBuilder = sqlbuilder.WithSession(clone.BaseDatabase, template)
+
+	return clone, nil
+}
+
+func (d *database) ConvertValues(values []interface{}) []interface{} {
+	for i := range values {
+		switch v := values[i].(type) {
+		case *string, *bool, *int, *uint, *int64, *uint64, *int32, *uint32, *int16, *uint16, *int8, *uint8, *float32, *float64, *[]uint8, sql.Scanner, *sql.Scanner, *time.Time:
+			// Handled by pq.
+		case string, bool, int, uint, int64, uint64, int32, uint32, int16, uint16, int8, uint8, float32, float64, []uint8, driver.Valuer, *driver.Valuer, time.Time:
+			// Handled by pq.
+		case StringArray, Int64Array, BoolArray, GenericArray, Float64Array, JSONBMap, JSONB:
+			// Already with scanner/valuer.
+		case *StringArray, *Int64Array, *BoolArray, *GenericArray, *Float64Array, *JSONBMap, *JSONB:
+			// Already with scanner/valuer.
+
+		case *[]int64:
+			values[i] = (*Int64Array)(v)
+		case *[]string:
+			values[i] = (*StringArray)(v)
+		case *[]float64:
+			values[i] = (*Float64Array)(v)
+		case *[]bool:
+			values[i] = (*BoolArray)(v)
+		case *map[string]interface{}:
+			values[i] = (*JSONBMap)(v)
+
+		case []int64:
+			values[i] = (*Int64Array)(&v)
+		case []string:
+			values[i] = (*StringArray)(&v)
+		case []float64:
+			values[i] = (*Float64Array)(&v)
+		case []bool:
+			values[i] = (*BoolArray)(&v)
+		case map[string]interface{}:
+			values[i] = (*JSONBMap)(&v)
+
+		case sqlbuilder.ValueWrapper:
+			values[i] = v.WrapValue(v)
+
+		default:
+			values[i] = autoWrap(reflect.ValueOf(values[i]), values[i])
+		}
+
+	}
+	return values
+}
+
+// CompileStatement compiles a *exql.Statement into arguments that sql/database
+// accepts.
+func (d *database) CompileStatement(stmt *exql.Statement, args []interface{}) (string, []interface{}) {
+	compiled, err := stmt.Compile(template)
+	if err != nil {
+		panic(err.Error())
+	}
+	query, args := sqlbuilder.Preprocess(compiled, args)
+	return sqladapter.ReplaceWithDollarSign(query), args
+}
+
+// Err allows sqladapter to translate specific CockroachDB string errors into
+// custom error values.
+func (d *database) Err(err error) error {
+	if err != nil {
+		s := err.Error()
+		// These errors are not exported so we have to check them by they string value.
+		if strings.Contains(s, `too many clients`) || strings.Contains(s, `remaining connection slots are reserved`) || strings.Contains(s, `too many open`) {
+			return db.ErrTooManyClients
+		}
+	}
+	return err
+}
+
+// NewCollection creates a db.Collection by name.
+func (d *database) NewCollection(name string) db.Collection {
+	return newCollection(d, name)
+}
+
+func RunTx(d sqlbuilder.Database, ctx context.Context, fn func(tx sqlbuilder.Tx) error) error {
+	tx, err := d.NewTx(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Close()
+	return ExecuteInTx(ctx, tx, func() error { return fn(tx) })
+}
+
+// Tx creates a transaction block on the given context and passes it to the
+// function fn. If fn returns no error the transaction is commited, else the
+// transaction is rolled back. After being commited or rolled back the
+// transaction is closed automatically.
+func (d *database) Tx(ctx context.Context, fn func(tx sqlbuilder.Tx) error) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return RunTx(d, ctx, fn)
+}
+
+// NewDatabaseTx begins a transaction block.
+func (d *database) NewDatabaseTx(ctx context.Context) (sqladapter.DatabaseTx, error) {
+	clone, err := d.clone(ctx, true)
+	if err != nil {
+		return nil, err
+	}
+	clone.mu.Lock()
+	defer clone.mu.Unlock()
+
+	connFn := func() error {
+		sqlTx, err := compat.BeginTx(clone.BaseDatabase.Session(), ctx, clone.TxOptions())
+		if err == nil {
+			return clone.BindTx(ctx, sqlTx)
+		}
+		return err
+	}
+
+	if err := clone.BaseDatabase.WaitForConnection(connFn); err != nil {
+		return nil, err
+	}
+
+	return sqladapter.NewDatabaseTx(clone), nil
+}
+
+// LookupName looks for the name of the database and it's often used as a
+// test to determine if the connection settings are valid.
+func (d *database) LookupName() (string, error) {
+	q := d.Select(db.Raw("CURRENT_DATABASE() AS name"))
+
+	iter := q.Iterator()
+	defer iter.Close()
+
+	if iter.Next() {
+		var name string
+		err := iter.Scan(&name)
+		return name, err
+	}
+
+	return "", iter.Err()
+}
+
+// TableExists returns an error if the given table name does not exist on the
+// database.
+func (d *database) TableExists(name string) error {
+	q := d.Select("table_name").
+		From("information_schema.tables").
+		Where("table_catalog = ? AND table_name = ?", d.BaseDatabase.Name(), name)
+
+	iter := q.Iterator()
+	defer iter.Close()
+
+	if iter.Next() {
+		var name string
+		if err := iter.Scan(&name); err != nil {
+			return err
+		}
+		return nil
+	}
+	return db.ErrCollectionDoesNotExist
+}
+
+// quotedTableName returns a valid regclass name for both regular tables and
+// for schemas.
+func quotedTableName(s string) string {
+	chunks := strings.Split(s, ".")
+	for i := range chunks {
+		chunks[i] = fmt.Sprintf("%q", chunks[i])
+	}
+	return strings.Join(chunks, ".")
+}
+
+// PrimaryKeys returns the names of all the primary keys on the table.
+func (d *database) PrimaryKeys(tableName string) ([]string, error) {
+	q := d.Select("column_name AS pkey").
+		From("information_schema.table_constraints tc").
+		Join("information_schema.key_column_usage kcu").
+		On("kcu.table_schema=tc.table_schema AND kcu.table_name=tc.table_name AND kcu.constraint_name = tc.constraint_name").
+		Where(`
+			tc.table_name = '` + tableName + `'
+			AND tc.table_schema = '`+d.Name()+`'
+			AND tc.constraint_type = 'PRIMARY KEY'
+		`).OrderBy("pkey")
+
+	iter := q.Iterator()
+	defer iter.Close()
+
+	pk := []string{}
+
+	for iter.Next() {
+		var k string
+		if err := iter.Scan(&k); err != nil {
+			return nil, err
+		}
+		pk = append(pk, k)
+	}
+	if err := iter.Err(); err != nil {
+		return nil, err
+	}
+
+	return pk, nil
+}
+
+// WithContext creates a copy of the session on the given context.
+func (d *database) WithContext(ctx context.Context) sqlbuilder.Database {
+	newDB, _ := d.clone(ctx, false)
+	return newDB
+}

--- a/cockroachdb/error.go
+++ b/cockroachdb/error.go
@@ -1,0 +1,52 @@
+//borrowed from https://github.com/cockroachdb/cockroach-go/blob/master/crdb/tx.go
+package cockroachdb
+
+import "fmt"
+
+type txError struct {
+	cause error
+}
+
+// Error implements the error interface
+func (e *txError) Error() string { return e.cause.Error() }
+
+// Cause returns the error encountered by the "ROLLBACK TO SAVEPOINT
+// cockroach_restart" statement. This method also implements the internal
+// pkg/errors.causer interface, so TxnRestartError works with pkg/errors.Cause().
+func (e *txError) Cause() error { return e.cause }
+
+// AmbiguousCommitError represents an error that left a transaction in an
+// ambiguous state: unclear if it committed or not.
+type AmbiguousCommitError struct {
+	txError
+}
+
+func newAmbiguousCommitError(err error) *AmbiguousCommitError {
+	return &AmbiguousCommitError{txError{cause: err}}
+}
+
+// TxnRestartError represents an error when restarting a transaction. `cause` is
+// the error from restarting the txn and `retryCause` is the original error which
+// triggered the restart.
+type TxnRestartError struct {
+	txError
+	retryCause error
+	msg        string
+}
+
+func newTxnRestartError(err error, retryErr error) *TxnRestartError {
+	const msgPattern = "restarting txn failed. ROLLBACK TO SAVEPOINT " +
+		"encountered error: %s. Original error: %s."
+	return &TxnRestartError{
+		txError:    txError{cause: err},
+		retryCause: retryErr,
+		msg:        fmt.Sprintf(msgPattern, err, retryErr),
+	}
+}
+
+// Error implements the error interface
+func (e *TxnRestartError) Error() string { return e.msg }
+
+// RetryCause returns the error encountered by the transaction, which caused the
+// transaction to be restarted.
+func (e *TxnRestartError) RetryCause() error { return e.retryCause }

--- a/cockroachdb/local_test.go
+++ b/cockroachdb/local_test.go
@@ -1,0 +1,283 @@
+package cockroachdb
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"upper.io/db.v3"
+)
+
+func TestStringAndInt64Array(t *testing.T) {
+	sess := mustOpen()
+	driver := sess.Driver().(*sql.DB)
+
+	defer func() {
+		driver.Exec(`DROP TABLE IF EXISTS array_types`)
+		sess.Close()
+	}()
+
+	if _, err := driver.Exec(`
+		CREATE TABLE array_types (
+			id serial primary key,
+			integers bigint[] DEFAULT NULL,
+			strings varchar(64)[]
+		)`); err != nil {
+		assert.NoError(t, err)
+	}
+
+	arrayTypes := sess.Collection("array_types")
+	err := arrayTypes.Truncate()
+	assert.NoError(t, err)
+
+	type arrayType struct {
+		ID       int64       `db:"id,pk"`
+		Integers Int64Array  `db:"integers"`
+		Strings  StringArray `db:"strings"`
+	}
+
+	tt := []arrayType{
+		// Test nil arrays.
+		arrayType{
+			ID:       1,
+			Integers: nil,
+			Strings:  nil,
+		},
+
+		// Test empty arrays.
+		arrayType{
+			ID:       2,
+			Integers: []int64{},
+			Strings:  []string{},
+		},
+
+		// Test non-empty arrays.
+		arrayType{
+			ID:       3,
+			Integers: []int64{1, 2, 3},
+			Strings:  []string{"1", "2", "3"},
+		},
+	}
+
+	for _, item := range tt {
+		id, err := arrayTypes.Insert(item)
+		assert.NoError(t, err)
+
+		if pk, ok := id.(int64); !ok || pk == 0 {
+			t.Fatalf("Expecting an ID.")
+		}
+
+		var itemCheck arrayType
+		err = arrayTypes.Find(db.Cond{"id": id}).One(&itemCheck)
+		assert.NoError(t, err)
+		assert.Len(t, itemCheck.Integers, len(item.Integers))
+		assert.Len(t, itemCheck.Strings, len(item.Strings))
+
+		assert.Equal(t, item, itemCheck)
+	}
+}
+
+func TestIssue210(t *testing.T) {
+	list := []string{
+		`DROP TABLE IF EXISTS testing123`,
+		`DROP TABLE IF EXISTS hello`,
+		`CREATE TABLE IF NOT EXISTS testing123 (
+			ID INT PRIMARY KEY     NOT NULL,
+			NAME           TEXT    NOT NULL
+		)
+		`,
+		`CREATE TABLE IF NOT EXISTS hello (
+			ID INT PRIMARY KEY     NOT NULL,
+			NAME           TEXT    NOT NULL
+		)`,
+	}
+
+	sess := mustOpen()
+	defer sess.Close()
+
+	tx, err := sess.NewTx(nil)
+	assert.NoError(t, err)
+
+	for i := range list {
+		_, err = tx.Exec(list[i])
+		assert.NoError(t, err)
+	}
+
+	err = tx.Commit()
+	assert.NoError(t, err)
+
+	_, err = sess.Collection("testing123").Find().Count()
+	assert.NoError(t, err)
+
+	_, err = sess.Collection("hello").Find().Count()
+	assert.NoError(t, err)
+}
+
+func TestPreparedStatements(t *testing.T) {
+	sess := mustOpen()
+	defer sess.Close()
+
+	var val int
+
+	{
+		stmt, err := sess.Prepare(`SELECT 1`)
+		assert.NoError(t, err)
+		assert.NotNil(t, stmt)
+
+		q, err := stmt.Query()
+		assert.NoError(t, err)
+		assert.NotNil(t, q)
+		assert.True(t, q.Next())
+
+		err = q.Scan(&val)
+		assert.NoError(t, err)
+
+		err = q.Close()
+		assert.NoError(t, err)
+
+		assert.Equal(t, 1, val)
+
+		err = stmt.Close()
+		assert.NoError(t, err)
+	}
+
+	{
+		tx, err := sess.NewTx(nil)
+		assert.NoError(t, err)
+
+		stmt, err := tx.Prepare(`SELECT 2`)
+		assert.NoError(t, err)
+		assert.NotNil(t, stmt)
+
+		q, err := stmt.Query()
+		assert.NoError(t, err)
+		assert.NotNil(t, q)
+		assert.True(t, q.Next())
+
+		err = q.Scan(&val)
+		assert.NoError(t, err)
+
+		err = q.Close()
+		assert.NoError(t, err)
+
+		assert.Equal(t, 2, val)
+
+		err = stmt.Close()
+		assert.NoError(t, err)
+
+		err = tx.Commit()
+		assert.NoError(t, err)
+	}
+
+	{
+		stmt, err := sess.Select(3).Prepare()
+		assert.NoError(t, err)
+		assert.NotNil(t, stmt)
+
+		q, err := stmt.Query()
+		assert.NoError(t, err)
+		assert.NotNil(t, q)
+		assert.True(t, q.Next())
+
+		err = q.Scan(&val)
+		assert.NoError(t, err)
+
+		err = q.Close()
+		assert.NoError(t, err)
+
+		assert.Equal(t, 3, val)
+
+		err = stmt.Close()
+		assert.NoError(t, err)
+	}
+}
+
+func TestNonTrivialSubqueries(t *testing.T) {
+	return
+	sess := mustOpen()
+	defer sess.Close()
+	/* TODO
+	{
+		q, err := sess.Query(`WITH test AS (?) ?`,
+			sess.Select("id AS foo").From("artist"),
+			sess.Select("foo").From("test").Where("foo > ?", 0),
+		)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, q)
+
+		assert.True(t, q.Next())
+
+		var number int
+		assert.NoError(t, q.Scan(&number))
+
+		assert.Equal(t, 1, number)
+		assert.NoError(t, q.Close())
+	}
+
+	{
+		row, err := sess.QueryRow(`WITH test AS (?) ?`,
+			sess.Select("id AS foo").From("artist"),
+			sess.Select("foo").From("test").Where("foo > ?", 0),
+		)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, row)
+
+		var number int
+		assert.NoError(t, row.Scan(&number))
+
+		assert.Equal(t, 1, number)
+	}*/
+
+	/*TODO:{
+		res, err := sess.Exec(`UPDATE artist a1 SET id = ?`,
+			sess.Select(db.Raw("id + 1")).From("artist a2").Where("a2.id = a1.id"),
+		)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, res)
+	}*/
+	/*
+	{
+		q, err := sess.Query(db.Raw(`WITH test AS (?) ?`,
+			sess.Select("id AS foo").From("artist"),
+			sess.Select("foo").From("test").Where("foo > ?", 0),
+		))
+
+		assert.NoError(t, err)
+		assert.NotNil(t, q)
+
+		assert.True(t, q.Next())
+
+		var number int
+		assert.NoError(t, q.Scan(&number))
+
+		assert.Equal(t, 2, number)
+		assert.NoError(t, q.Close())
+	}
+
+	{
+		row, err := sess.QueryRow(db.Raw(`WITH test AS (?) ?`,
+			sess.Select("id AS foo").From("artist"),
+			sess.Select("foo").From("test").Where("foo > ?", 0),
+		))
+
+		assert.NoError(t, err)
+		assert.NotNil(t, row)
+
+		var number int
+		assert.NoError(t, row.Scan(&number))
+
+		assert.Equal(t, 2, number)
+	}
+
+	{
+		res, err := sess.Exec(db.Raw(`UPDATE artist a1 SET id = ?`,
+			sess.Select(db.Raw("id + 1")).From("artist a2").Where("a2.id = a1.id"),
+		))
+
+		assert.NoError(t, err)
+		assert.NotNil(t, res)
+	}*/
+}

--- a/cockroachdb/postgresql.go
+++ b/cockroachdb/postgresql.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2012-present The upper.io/db authors. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package cockroachdb // import "upper.io/db.v3/postgresql"
+
+import (
+	"database/sql"
+
+	"upper.io/db.v3"
+
+	"upper.io/db.v3/internal/sqladapter"
+	"upper.io/db.v3/lib/sqlbuilder"
+)
+
+const sqlDriver = `postgres`
+
+// Adapter is the unique name that you can use to refer to this adapter.
+const Adapter = `postgresql`
+
+func init() {
+	sqlbuilder.RegisterAdapter(Adapter, &sqlbuilder.AdapterFuncMap{
+		New:   New,
+		NewTx: NewTx,
+		Open:  Open,
+	})
+}
+
+// Open opens a new connection with the PostgreSQL server. The returned session
+// is validated first by Ping and then with a test query before being returned.
+// You may call Open() just once and use it on multiple goroutines on a
+// long-running program. See https://golang.org/pkg/database/sql/#Open and
+// http://go-database-sql.org/accessing.html
+func Open(settings db.ConnectionURL) (sqlbuilder.Database, error) {
+	d := newDatabase(settings)
+	if err := d.Open(settings); err != nil {
+		return nil, err
+	}
+	return d, nil
+}
+
+// NewTx wraps a regular *sql.Tx transaction and returns a new upper-db
+// transaction backed by it.
+func NewTx(sqlTx *sql.Tx) (sqlbuilder.Tx, error) {
+	d := newDatabase(nil)
+
+	// Binding with sqladapter's logic.
+	d.BaseDatabase = sqladapter.NewBaseDatabase(d)
+
+	// Binding with sqlbuilder.
+	d.SQLBuilder = sqlbuilder.WithSession(d.BaseDatabase, template)
+
+	if err := d.BaseDatabase.BindTx(d.Context(), sqlTx); err != nil {
+		return nil, err
+	}
+
+	newTx := sqladapter.NewDatabaseTx(d)
+	return &tx{DatabaseTx: newTx}, nil
+}
+
+// New wraps a regular *sql.DB session and creates a new upper-db session
+// backed by it.
+func New(sess *sql.DB) (sqlbuilder.Database, error) {
+	d := newDatabase(nil)
+
+	// Binding with sqladapter's logic.
+	d.BaseDatabase = sqladapter.NewBaseDatabase(d)
+
+	// Binding with sqlbuilder.
+	d.SQLBuilder = sqlbuilder.WithSession(d.BaseDatabase, template)
+
+	if err := d.BaseDatabase.BindSession(sess); err != nil {
+		return nil, err
+	}
+	return d, nil
+}

--- a/cockroachdb/stubs_test.go
+++ b/cockroachdb/stubs_test.go
@@ -1,0 +1,18 @@
+// +build !generated
+
+package cockroachdb
+
+import (
+	"log"
+	"testing"
+
+	"upper.io/db.v3/lib/sqlbuilder"
+)
+
+func mustOpen() sqlbuilder.Database {
+	return nil
+}
+
+func TestMain(*testing.M) {
+	log.Fatal(`Tests use generated code and a custom database, please use "make test".`)
+}

--- a/cockroachdb/template.go
+++ b/cockroachdb/template.go
@@ -1,0 +1,211 @@
+// Copyright (c) 2012-present The upper.io/db authors. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package cockroachdb
+
+import (
+	"upper.io/db.v3"
+	"upper.io/db.v3/internal/cache"
+	"upper.io/db.v3/internal/sqladapter/exql"
+)
+
+const (
+	adapterColumnSeparator     = `.`
+	adapterIdentifierSeparator = `, `
+	adapterIdentifierQuote     = `"{{.Value}}"`
+	adapterValueSeparator      = `, `
+	adapterValueQuote          = `'{{.}}'`
+	adapterAndKeyword          = `AND`
+	adapterOrKeyword           = `OR`
+	adapterDescKeyword         = `DESC`
+	adapterAscKeyword          = `ASC`
+	adapterAssignmentOperator  = `=`
+	adapterClauseGroup         = `({{.}})`
+	adapterClauseOperator      = ` {{.}} `
+	adapterColumnValue         = `{{.Column}} {{.Operator}} {{.Value}}`
+	adapterTableAliasLayout    = `{{.Name}}{{if .Alias}} AS {{.Alias}}{{end}}`
+	adapterColumnAliasLayout   = `{{.Name}}{{if .Alias}} AS {{.Alias}}{{end}}`
+	adapterSortByColumnLayout  = `{{.Column}} {{.Order}}`
+
+	adapterOrderByLayout = `
+    {{if .SortColumns}}
+      ORDER BY {{.SortColumns}}
+    {{end}}
+  `
+
+	adapterWhereLayout = `
+    {{if .Conds}}
+      WHERE {{.Conds}}
+    {{end}}
+  `
+
+	adapterUsingLayout = `
+    {{if .Columns}}
+      USING ({{.Columns}})
+    {{end}}
+  `
+
+	adapterJoinLayout = `
+    {{if .Table}}
+      {{ if .On }}
+        {{.Type}} JOIN {{.Table}}
+        {{.On}}
+      {{ else if .Using }}
+        {{.Type}} JOIN {{.Table}}
+        {{.Using}}
+      {{ else if .Type | eq "CROSS" }}
+        {{.Type}} JOIN {{.Table}}
+      {{else}}
+        NATURAL {{.Type}} JOIN {{.Table}}
+      {{end}}
+    {{end}}
+  `
+
+	adapterOnLayout = `
+    {{if .Conds}}
+      ON {{.Conds}}
+    {{end}}
+  `
+
+	adapterSelectLayout = `
+    SELECT
+      {{if .Distinct}}
+        DISTINCT
+      {{end}}
+
+      {{if .Columns}}
+        {{.Columns}}
+      {{else}}
+        *
+      {{end}}
+
+      {{if .Table}}
+        FROM {{.Table}}
+      {{end}}
+
+      {{.Joins}}
+
+      {{.Where}}
+
+      {{.GroupBy}}
+
+      {{.OrderBy}}
+
+      {{if .Limit}}
+        LIMIT {{.Limit}}
+      {{end}}
+
+      {{if .Offset}}
+        {{if not .Limit}}
+          LIMIT -1
+        {{end}}
+        OFFSET {{.Offset}}
+      {{end}}
+  `
+	adapterDeleteLayout = `
+    DELETE
+      FROM {{.Table}}
+      {{.Where}}
+  `
+	adapterUpdateLayout = `
+    UPDATE
+      {{.Table}}
+    SET {{.ColumnValues}}
+      {{ .Where }}
+  `
+
+	adapterSelectCountLayout = `
+    SELECT
+      COUNT(1) AS _t
+    FROM {{.Table}}
+      {{.Where}}
+  `
+
+	adapterInsertLayout = `
+    INSERT INTO {{.Table}}
+      {{if .Columns }}({{.Columns}}){{end}}
+    VALUES
+    {{if .Values}}
+      {{.Values}}
+    {{else}}
+      (default)
+    {{end}}
+    {{if .Returning}}
+      RETURNING {{.Returning}}
+    {{end}}
+  `
+
+	adapterTruncateLayout = `
+    TRUNCATE TABLE {{.Table}}
+  `
+
+	adapterDropDatabaseLayout = `
+    DROP DATABASE {{.Database}}
+  `
+
+	adapterDropTableLayout = `
+    DROP TABLE {{.Table}}
+  `
+
+	adapterGroupByLayout = `
+    {{if .GroupColumns}}
+      GROUP BY {{.GroupColumns}}
+    {{end}}
+  `
+)
+
+var template = &exql.Template{
+	ColumnSeparator:     adapterColumnSeparator,
+	IdentifierSeparator: adapterIdentifierSeparator,
+	IdentifierQuote:     adapterIdentifierQuote,
+	ValueSeparator:      adapterValueSeparator,
+	ValueQuote:          adapterValueQuote,
+	AndKeyword:          adapterAndKeyword,
+	OrKeyword:           adapterOrKeyword,
+	DescKeyword:         adapterDescKeyword,
+	AscKeyword:          adapterAscKeyword,
+	AssignmentOperator:  adapterAssignmentOperator,
+	ClauseGroup:         adapterClauseGroup,
+	ClauseOperator:      adapterClauseOperator,
+	ColumnValue:         adapterColumnValue,
+	TableAliasLayout:    adapterTableAliasLayout,
+	ColumnAliasLayout:   adapterColumnAliasLayout,
+	SortByColumnLayout:  adapterSortByColumnLayout,
+	WhereLayout:         adapterWhereLayout,
+	JoinLayout:          adapterJoinLayout,
+	OnLayout:            adapterOnLayout,
+	UsingLayout:         adapterUsingLayout,
+	OrderByLayout:       adapterOrderByLayout,
+	InsertLayout:        adapterInsertLayout,
+	SelectLayout:        adapterSelectLayout,
+	UpdateLayout:        adapterUpdateLayout,
+	DeleteLayout:        adapterDeleteLayout,
+	TruncateLayout:      adapterTruncateLayout,
+	DropDatabaseLayout:  adapterDropDatabaseLayout,
+	DropTableLayout:     adapterDropTableLayout,
+	CountLayout:         adapterSelectCountLayout,
+	GroupByLayout:       adapterGroupByLayout,
+	Cache:               cache.NewCache(),
+	ComparisonOperator: map[db.ComparisonOperator]string{
+		db.ComparisonOperatorRegExp:    "~",
+		db.ComparisonOperatorNotRegExp: "!~",
+	},
+}

--- a/cockroachdb/template_test.go
+++ b/cockroachdb/template_test.go
@@ -1,0 +1,247 @@
+package cockroachdb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"upper.io/db.v3"
+	"upper.io/db.v3/lib/sqlbuilder"
+)
+
+func TestTemplateSelect(t *testing.T) {
+
+	b := sqlbuilder.WithTemplate(template)
+	assert := assert.New(t)
+
+	assert.Equal(
+		`SELECT * FROM "artist"`,
+		b.SelectFrom("artist").String(),
+	)
+
+	assert.Equal(
+		`SELECT * FROM "artist"`,
+		b.Select().From("artist").String(),
+	)
+
+	assert.Equal(
+		`SELECT * FROM "artist" ORDER BY "name" DESC`,
+		b.Select().From("artist").OrderBy("name DESC").String(),
+	)
+
+	assert.Equal(
+		`SELECT * FROM "artist" ORDER BY "name" DESC`,
+		b.Select().From("artist").OrderBy("-name").String(),
+	)
+
+	assert.Equal(
+		`SELECT * FROM "artist" ORDER BY "name" ASC`,
+		b.Select().From("artist").OrderBy("name").String(),
+	)
+
+	assert.Equal(
+		`SELECT * FROM "artist" ORDER BY "name" ASC`,
+		b.Select().From("artist").OrderBy("name ASC").String(),
+	)
+
+	assert.Equal(
+		`SELECT * FROM "artist" LIMIT -1 OFFSET 5`,
+		b.Select().From("artist").Limit(-1).Offset(5).String(),
+	)
+
+	assert.Equal(
+		`SELECT "id" FROM "artist"`,
+		b.Select("id").From("artist").String(),
+	)
+
+	assert.Equal(
+		`SELECT "id", "name" FROM "artist"`,
+		b.Select("id", "name").From("artist").String(),
+	)
+
+	assert.Equal(
+		`SELECT * FROM "artist" WHERE ("name" = $1)`,
+		b.SelectFrom("artist").Where("name", "Haruki").String(),
+	)
+
+	assert.Equal(
+		`SELECT * FROM "artist" WHERE (name LIKE $1)`,
+		b.SelectFrom("artist").Where("name LIKE ?", `%F%`).String(),
+	)
+
+	assert.Equal(
+		`SELECT "id" FROM "artist" WHERE (name LIKE $1 OR name LIKE $2)`,
+		b.Select("id").From("artist").Where(`name LIKE ? OR name LIKE ?`, `%Miya%`, `F%`).String(),
+	)
+
+	assert.Equal(
+		`SELECT * FROM "artist" WHERE ("id" > $1)`,
+		b.SelectFrom("artist").Where("id >", 2).String(),
+	)
+
+	assert.Equal(
+		`SELECT * FROM "artist" WHERE (id <= 2 AND name != $1)`,
+		b.SelectFrom("artist").Where("id <= 2 AND name != ?", "A").String(),
+	)
+
+	assert.Equal(
+		`SELECT * FROM "artist" WHERE ("id" IN ($1, $2, $3, $4))`,
+		b.SelectFrom("artist").Where("id IN", []int{1, 9, 8, 7}).String(),
+	)
+
+	assert.Equal(
+		`SELECT * FROM "artist" WHERE (name IS NOT NULL)`,
+		b.SelectFrom("artist").Where("name IS NOT NULL").String(),
+	)
+
+	assert.Equal(
+		`SELECT * FROM "artist" AS "a", "publication" AS "p" WHERE (p.author_id = a.id) LIMIT 1`,
+		b.Select().From("artist a", "publication as p").Where("p.author_id = a.id").Limit(1).String(),
+	)
+
+	assert.Equal(
+		`SELECT "id" FROM "artist" NATURAL JOIN "publication"`,
+		b.Select("id").From("artist").Join("publication").String(),
+	)
+
+	assert.Equal(
+		`SELECT * FROM "artist" AS "a" JOIN "publication" AS "p" ON (p.author_id = a.id) LIMIT 1`,
+		b.SelectFrom("artist a").Join("publication p").On("p.author_id = a.id").Limit(1).String(),
+	)
+
+	assert.Equal(
+		`SELECT * FROM "artist" AS "a" JOIN "publication" AS "p" ON (p.author_id = a.id) WHERE ("a"."id" = $1) LIMIT 1`,
+		b.SelectFrom("artist a").Join("publication p").On("p.author_id = a.id").Where("a.id", 2).Limit(1).String(),
+	)
+
+	assert.Equal(
+		`SELECT * FROM "artist" JOIN "publication" AS "p" ON (p.author_id = a.id) WHERE (a.id = 2) LIMIT 1`,
+		b.SelectFrom("artist").Join("publication p").On("p.author_id = a.id").Where("a.id = 2").Limit(1).String(),
+	)
+
+	assert.Equal(
+		`SELECT * FROM "artist" AS "a" JOIN "publication" AS "p" ON (p.title LIKE $1 OR p.title LIKE $2) WHERE (a.id = $3) LIMIT 1`,
+		b.SelectFrom("artist a").Join("publication p").On("p.title LIKE ? OR p.title LIKE ?", "%Totoro%", "%Robot%").Where("a.id = ?", 2).Limit(1).String(),
+	)
+
+	assert.Equal(
+		`SELECT * FROM "artist" AS "a" LEFT JOIN "publication" AS "p1" ON (p1.id = a.id) RIGHT JOIN "publication" AS "p2" ON (p2.id = a.id)`,
+		b.SelectFrom("artist a").
+			LeftJoin("publication p1").On("p1.id = a.id").
+			RightJoin("publication p2").On("p2.id = a.id").
+			String(),
+	)
+
+	assert.Equal(
+		`SELECT * FROM "artist" CROSS JOIN "publication"`,
+		b.SelectFrom("artist").CrossJoin("publication").String(),
+	)
+
+	assert.Equal(
+		`SELECT * FROM "artist" JOIN "publication" USING ("id")`,
+		b.SelectFrom("artist").Join("publication").Using("id").String(),
+	)
+
+	assert.Equal(
+		`SELECT DATE()`,
+		b.Select(db.Raw("DATE()")).String(),
+	)
+}
+
+func TestTemplateInsert(t *testing.T) {
+	b := sqlbuilder.WithTemplate(template)
+	assert := assert.New(t)
+
+	assert.Equal(
+		`INSERT INTO "artist" VALUES ($1, $2), ($3, $4), ($5, $6)`,
+		b.InsertInto("artist").
+			Values(10, "Ryuichi Sakamoto").
+			Values(11, "Alondra de la Parra").
+			Values(12, "Haruki Murakami").
+			String(),
+	)
+
+	assert.Equal(
+		`INSERT INTO "artist" ("id", "name") VALUES ($1, $2)`,
+		b.InsertInto("artist").Values(map[string]string{"id": "12", "name": "Chavela Vargas"}).String(),
+	)
+
+	assert.Equal(
+		`INSERT INTO "artist" ("id", "name") VALUES ($1, $2) RETURNING "id"`,
+		b.InsertInto("artist").Values(map[string]string{"id": "12", "name": "Chavela Vargas"}).Returning("id").String(),
+	)
+
+	assert.Equal(
+		`INSERT INTO "artist" ("id", "name") VALUES ($1, $2)`,
+		b.InsertInto("artist").Values(map[string]interface{}{"name": "Chavela Vargas", "id": 12}).String(),
+	)
+
+	assert.Equal(
+		`INSERT INTO "artist" ("id", "name") VALUES ($1, $2)`,
+		b.InsertInto("artist").Values(struct {
+			ID   int    `db:"id"`
+			Name string `db:"name"`
+		}{12, "Chavela Vargas"}).String(),
+	)
+
+	assert.Equal(
+		`INSERT INTO "artist" ("name", "id") VALUES ($1, $2)`,
+		b.InsertInto("artist").Columns("name", "id").Values("Chavela Vargas", 12).String(),
+	)
+}
+
+func TestTemplateUpdate(t *testing.T) {
+	b := sqlbuilder.WithTemplate(template)
+	assert := assert.New(t)
+
+	assert.Equal(
+		`UPDATE "artist" SET "name" = $1`,
+		b.Update("artist").Set("name", "Artist").String(),
+	)
+
+	assert.Equal(
+		`UPDATE "artist" SET "name" = $1 WHERE ("id" < $2)`,
+		b.Update("artist").Set("name = ?", "Artist").Where("id <", 5).String(),
+	)
+
+	assert.Equal(
+		`UPDATE "artist" SET "name" = $1 WHERE ("id" < $2)`,
+		b.Update("artist").Set(map[string]string{"name": "Artist"}).Where(db.Cond{"id <": 5}).String(),
+	)
+
+	assert.Equal(
+		`UPDATE "artist" SET "name" = $1 WHERE ("id" < $2)`,
+		b.Update("artist").Set(struct {
+			Nombre string `db:"name"`
+		}{"Artist"}).Where(db.Cond{"id <": 5}).String(),
+	)
+
+	assert.Equal(
+		`UPDATE "artist" SET "name" = $1, "last_name" = $2 WHERE ("id" < $3)`,
+		b.Update("artist").Set(struct {
+			Nombre string `db:"name"`
+		}{"Artist"}).Set(map[string]string{"last_name": "Foo"}).Where(db.Cond{"id <": 5}).String(),
+	)
+
+	assert.Equal(
+		`UPDATE "artist" SET "name" = $1 || ' ' || $2 || id, "id" = id + $3 WHERE (id > $4)`,
+		b.Update("artist").Set(
+			"name = ? || ' ' || ? || id", "Artist", "#",
+			"id = id + ?", 10,
+		).Where("id > ?", 0).String(),
+	)
+}
+
+func TestTemplateDelete(t *testing.T) {
+	b := sqlbuilder.WithTemplate(template)
+	assert := assert.New(t)
+
+	assert.Equal(
+		`DELETE FROM "artist" WHERE (name = $1)`,
+		b.DeleteFrom("artist").Where("name = ?", "Chavela Vargas").Limit(1).String(),
+	)
+
+	assert.Equal(
+		`DELETE FROM "artist" WHERE (id > 5)`,
+		b.DeleteFrom("artist").Where("id > 5").String(),
+	)
+}

--- a/cockroachdb/tx.go
+++ b/cockroachdb/tx.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2012-present The upper.io/db authors. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package cockroachdb
+
+import (
+	"context"
+
+	"upper.io/db.v3/internal/sqladapter"
+	"upper.io/db.v3/lib/sqlbuilder"
+	"github.com/lib/pq"
+)
+
+type tx struct {
+	sqladapter.DatabaseTx
+}
+
+var (
+	_ = sqlbuilder.Tx(&tx{})
+)
+
+func (t *tx) WithContext(ctx context.Context) sqlbuilder.Tx {
+	var newTx tx
+	newTx = *t
+	newTx.DatabaseTx.SetContext(ctx)
+	return &newTx
+}
+
+// ExecuteInTx runs fn inside tx which should already have begun.
+// *WARNING*: Do not execute any statements on the supplied tx before calling this function.
+// ExecuteInTx will only retry statements that are performed within the supplied
+// closure (fn). Any statements performed on the tx before ExecuteInTx is invoked will *not*
+// be re-run if the transaction needs to be retried.
+// borrowed from https://github.com/cockroachdb/cockroach-go/blob/master/crdb/tx.go
+func ExecuteInTx(ctx context.Context, tx sqlbuilder.Tx, fn func() error) (err error) {
+
+	defer func() {
+		if err == nil {
+			// Ignore commit errors. The tx has already been committed by RELEASE.
+			_ = tx.Commit()
+		} else {
+			// We always need to execute a Rollback() so sql.DB releases the
+			// connection.
+			_ = tx.Rollback()
+		}
+	}()
+	// Specify that we intend to retry this txn in case of CockroachDB retryable
+	// errors.
+	if _, err = tx.ExecContext(ctx, "SAVEPOINT cockroach_restart"); err != nil {
+		return err
+	}
+
+	for {
+		released := false
+		err = fn()
+		if err == nil {
+			// RELEASE acts like COMMIT in CockroachDB. We use it since it gives us an
+			// opportunity to react to retryable errors, whereas tx.Commit() doesn't.
+			released = true
+			if _, err = tx.ExecContext(ctx, "RELEASE SAVEPOINT cockroach_restart"); err == nil {
+				return nil
+			}
+		}
+		// We got an error; let's see if it's a retryable one and, if so, restart. We look
+		// for either the standard PG errcode SerializationFailureError:40001 or the Cockroach extension
+		// errcode RetriableError:CR000. The Cockroach extension has been removed server-side, but support
+		// for it has been left here for now to maintain backwards compatibility.
+		pqErr, ok := err.(*pq.Error)
+		if retryable := ok && (pqErr.Code == "CR000" || pqErr.Code == "40001"); !retryable {
+			if released {
+				err = newAmbiguousCommitError(err)
+			}
+			return err
+		}
+		if _, retryErr := tx.ExecContext(ctx, "ROLLBACK TO SAVEPOINT cockroach_restart"); retryErr != nil {
+			return newTxnRestartError(retryErr, err)
+		}
+	}
+}


### PR DESCRIPTION
[CockroachDB](https://www.cockroachlabs.com) uses PostgreSQL client wire protocol, so mostly same as PostgreSQL. It is opensource and developed in GOlang. It has SQL API that supports distributed ACID transactions. But transaction logic and information schema handling is a bit different. Some properties of PostgreSQL are not supported yet (or not planned to support). Changes from PostgreSQL dialect:

- Commented `JSONB` support and tests as CockroachDB doesn't [support yet](cockroachdb/cockroach#2969).
- Corrected `database.PrimaryKeys` SELECT.
- Commented correlated support and tests CockroachDB doesn't support correlated selects.
- Added CockroachDB style transaction support  to `sqlbuilder.RunTx` from [cdrb](https://github.com/cockroachdb/cockroach-go/blob/master/crdb/tx.go)
- `TestTransactionsAndRollback` is failing because of a problem I couln't find(need help) because of something in test system. Same SQL's are successful in my sample application.
