### PR TITLE
mysql PrimaryKeys Use a faster solution

### DIFF
--- a/mysql/database.go
+++ b/mysql/database.go
@@ -277,13 +277,11 @@ func (d *database) TableExists(name string) error {
 }
 
 // PrimaryKeys returns the names of all the primary keys on the table.
-func (d *database) PrimaryKeys(tableName string) ([]string, error) {
+func (d *database) PrimaryKeys(tableName string) ([]string, error) {	
 	q := d.Select("k.column_name").
-		From("information_schema.table_constraints AS t").
-		Join("information_schema.key_column_usage AS k").
-		Using("constraint_name", "table_schema", "table_name").
+		Form("information_schema.key_column_usage AS k").
 		Where(`
-			t.constraint_type = 'primary key'
+			t.constraint_name = 'PRIMARY'
 			AND t.table_schema = ?
 			AND t.table_name = ?
 		`, d.BaseDatabase.Name(), tableName).

--- a/mysql/database.go
+++ b/mysql/database.go
@@ -281,9 +281,9 @@ func (d *database) PrimaryKeys(tableName string) ([]string, error) {
 	q := d.Select("k.column_name").
 		Form("information_schema.key_column_usage AS k").
 		Where(`
-			t.constraint_name = 'PRIMARY'
-			AND t.table_schema = ?
-			AND t.table_name = ?
+			k.constraint_name = 'PRIMARY'
+			AND k.table_schema = ?
+			AND k.table_name = ?
 		`, d.BaseDatabase.Name(), tableName).
 		OrderBy("k.ordinal_position")
 


### PR DESCRIPTION
In my local, the sql very slow, Need to 9 seconds
```
SELECT `k`.`column_name` FROM `information_schema`.`table_constraints` AS `t` JOIN `information_schema`.`key_column_usage` AS `k` USING (`constraint_name`, `table_schema`, `table_name`) WHERE (t.constraint_type = 'primary key' AND t.table_schema = "XXX" AND t.table_name = "users") ORDER BY `k`.`ordinal_position` ASC
```

I found some information, you can modify 
```
SELECT column_name
FROM   information_schema.key_column_usage
WHERE  table_schema = "XXX"        
AND    constraint_name = 'PRIMARY'       
 AND    table_name = 'users'  order BY ordinal_position
```

After exec time It only takes a few milliseconds

PS : https://stackoverflow.com/questions/2341278/get-primary-key-of-table