### PR TITLE
add string type

### DIFF
--- a/internal/sqladapter/sqladapter.go
+++ b/internal/sqladapter/sqladapter.go
@@ -23,6 +23,7 @@
 package sqladapter
 
 import (
+	"strconv"
 	"database/sql/driver"
 )
 
@@ -33,12 +34,17 @@ func IsKeyValue(v interface{}) bool {
 		return true
 	}
 	switch v.(type) {
-	case int64, int, uint, uint64, string,
-		[]int64, []int, []uint, []uint64,
-		[]byte, []string,
-		[]interface{},
-		driver.Valuer:
+	case int64, int, uint, uint64,
+	[]int64, []int, []uint, []uint64,
+	[]byte, []string,
+	[]interface{},
+	driver.Valuer:
 		return true
+	case string:
+		_, err := strconv.ParseInt(v.(string), 10, 64)
+		if err == nil {
+			return true
+		}
 	}
 	return false
 }

--- a/internal/sqladapter/sqladapter.go
+++ b/internal/sqladapter/sqladapter.go
@@ -33,7 +33,7 @@ func IsKeyValue(v interface{}) bool {
 		return true
 	}
 	switch v.(type) {
-	case int64, int, uint, uint64,
+	case int64, int, uint, uint64, string,
 		[]int64, []int, []uint, []uint64,
 		[]byte, []string,
 		[]interface{},


### PR DESCRIPTION
I think should string type, Because Find args is interface
If args is string:
```
user := &Users{}
var user_id sting
user_id = "4"
db.Collection("users").Find(user_id).One(user)
```

builder sql 

```
SELECT * FROM `users` WHERE (4)
```
This is dangerous in big data tables

So, return error or support string type