### PR TITLE
Do not set 'limit' to a negative value if 'offset' is specified for PostgreSQL database

### DIFF
--- a/postgresql/template.go
+++ b/postgresql/template.go
@@ -114,9 +114,6 @@ const (
       {{end}}
 
       {{if .Offset}}
-        {{if not .Limit}}
-          LIMIT -1
-        {{end}}
         OFFSET {{.Offset}}
       {{end}}
   `


### PR DESCRIPTION
If a developer specifies only the 'offset' parameter for a current result set (without the 'limit' one), the compiled query will contain "LIMIT -1 OFFSET ..." clause. Looks like the code responsible for this was copied from the SQLite adapter, but for PostgreSQL such syntax is invalid.