### PR TITLE
Uncomment Clone method that was definitely commented by mistake

### DIFF
--- a/database.go
+++ b/database.go
@@ -38,7 +38,7 @@ type Database interface {
 
 	// Clone duplicates the current database session. Returns an error if the
 	// clone did not succeed.
-	// Clone() (Database, error)
+	Clone() (Database, error)
 
 	// Ping returns an error if the database manager could not be reached.
 	Ping() error


### PR DESCRIPTION
It seems that a typo was made, and at the moment it's just impossible to clone session that is strongly affect performance.