### PR TITLE
MSSQL TableExists cannot find the table

### DIFF
--- a/mssql/database.go
+++ b/mssql/database.go
@@ -233,7 +233,7 @@ func (d *database) LookupName() (string, error) {
 func (d *database) TableExists(name string) error {
 	q := d.Select(`table_name`).
 		From(`information_schema.tables`).
-		Where(`table_schema`, d.BaseDatabase.Name()).
+		Where(db.Or(db.Cond{`table_schema`: d.BaseDatabase.Name()}, db.Cond{`table_catalog`: d.BaseDatabase.Name()} )).
 		And(`table_name`, name)
 
 	iter := q.Iterator()


### PR DESCRIPTION
There are different approaches on configuring and using your sql server:
 - create new `schemas`, `databases`
 - using default schema `dbo` etc...

**Current issue:**
When you use default `dbo` schema, it cannot find your collection table name in _schema information_ table. It makes a wrong query to `information_schema.tables` where `d.BaseDatabase.Name()` method returns the `database name` instead of `schema name`. The issue is that we are looking up for database name in _table_schema_ column, which in our case is `dbo`. So the record is not being found, and it is a problem.

**Solution:**
I have tried to make as small change as possible to not impact the original implementation, in case `d.BaseDatabase.Name()` would return the schema name instead of database name.
For that, I just add one more `Or` condition to check for database_name (_table_catalog_)
