### PR TITLE
Fix deadlock in sqladapter

### DIFF
--- a/internal/sqladapter/database.go
+++ b/internal/sqladapter/database.go
@@ -167,8 +167,6 @@ type database struct {
 	sess   *sql.DB
 	sessMu sync.Mutex
 
-	psMu sync.Mutex
-
 	sessID uint64
 	txID   uint64
 

--- a/internal/sqladapter/database.go
+++ b/internal/sqladapter/database.go
@@ -155,13 +155,15 @@ type database struct {
 
 	db.Settings
 
+	lookupNameOnce sync.Once
+	name           string
+
 	ctx       context.Context
 	txOptions *sql.TxOptions
 
 	collectionMu sync.Mutex
 	mu           sync.Mutex
 
-	name   string
 	sess   *sql.DB
 	sessMu sync.Mutex
 
@@ -243,12 +245,11 @@ func (d *database) Transaction() BaseTx {
 
 // Name returns the database named
 func (d *database) Name() string {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
-	if d.name == "" {
-		d.name, _ = d.PartialDatabase.LookupName()
-	}
+	d.lookupNameOnce.Do(func() {
+		if d.name == "" {
+			d.name, _ = d.PartialDatabase.LookupName()
+		}
+	})
 
 	return d.name
 }

--- a/internal/sqladapter/database.go
+++ b/internal/sqladapter/database.go
@@ -151,25 +151,23 @@ func NewBaseDatabase(p PartialDatabase) BaseDatabase {
 // BaseDatabase and PartialDatabase
 type database struct {
 	PartialDatabase
-	baseTx BaseTx
-
 	db.Settings
 
 	lookupNameOnce sync.Once
 	name           string
 
+	mu        sync.Mutex // guards ctx, txOptions
 	ctx       context.Context
 	txOptions *sql.TxOptions
 
-	collectionMu sync.Mutex
-	mu           sync.Mutex
-
+	sessMu sync.Mutex // guards sess, baseTx
 	sess   *sql.DB
-	sessMu sync.Mutex
+	baseTx BaseTx
 
 	sessID uint64
 	txID   uint64
 
+	cacheMu           sync.Mutex // guards cachedStatements and cachedCollections
 	cachedStatements  *cache.Cache
 	cachedCollections *cache.Cache
 
@@ -311,8 +309,8 @@ func (d *database) SetMaxOpenConns(n int) {
 
 // ClearCache removes all caches.
 func (d *database) ClearCache() {
-	d.collectionMu.Lock()
-	defer d.collectionMu.Unlock()
+	d.cacheMu.Lock()
+	defer d.cacheMu.Unlock()
 	d.cachedCollections.Clear()
 	d.cachedStatements.Clear()
 	if d.template != nil {
@@ -375,8 +373,8 @@ func (d *database) Close() error {
 
 // Collection returns a db.Collection given a name. Results are cached.
 func (d *database) Collection(name string) db.Collection {
-	d.collectionMu.Lock()
-	defer d.collectionMu.Unlock()
+	d.cacheMu.Lock()
+	defer d.cacheMu.Unlock()
 
 	h := cache.String(name)
 


### PR DESCRIPTION
Deadlock in db.v3/internal/sqladapter:

```
func (d *database) Name() string {

    d.mu.Lock()

    ...which calls  d.PartialDatabase.LookupName()

func (d *database) LookupName() (string, error) {

    ...which creates q.Iterator()

func (sel *selector) Iterator() Iterator {

    ...which calls sel.SQLBuilder().sess.Context()

func (d *database) Context() context.Context {

    d.mu.Lock()

    ...boom, a DEADLOCK!
```