### PR TITLE
Change module path to github.com + add Go modules support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.db
 *.tmp
 generated_*.go
+.idea
+.vscode

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ env:
     - TEST_CMD="make test-adapters"
 
 install:
-  - mkdir -p $GOPATH/src/upper.io
+  - mkdir -p $GOPATH/src/github.com/upper
   - mv $PWD $GOPATH/src/github.com/upper/db
   - cd $GOPATH/src/github.com/upper/db
   - go get -t -v -d ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,8 +45,8 @@ env:
 
 install:
   - mkdir -p $GOPATH/src/github.com/upper
-  - mv $PWD $GOPATH/src/github.com/upper/db
   - cd $GOPATH/src/github.com/upper/db
+  - ls -la
   - go get -t -v -d ./...
   - go get -v github.com/cznic/ql/ql
   - export TRAVIS_BUILD_DIR=$GOPATH/src/github.com/upper/db

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,11 +45,11 @@ env:
 
 install:
   - mkdir -p $GOPATH/src/upper.io
-  - mv $PWD $GOPATH/src/upper.io/db.v3
-  - cd $GOPATH/src/upper.io/db.v3
+  - mv $PWD $GOPATH/src/github.com/upper/db
+  - cd $GOPATH/src/github.com/upper/db
   - go get -t -v -d ./...
   - go get -v github.com/cznic/ql/ql
-  - export TRAVIS_BUILD_DIR=$GOPATH/src/upper.io/db.v3
+  - export TRAVIS_BUILD_DIR=$GOPATH/src/github.com/upper/db
 
 before_script:
   - docker exec -it mysql bash -c 'mysql_tzinfo_to_sql /usr/share/zoneinfo | mysql -u root mysql'

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <img src="https://upper.io/db.v3/images/gopher.svg" width="256" />
+  <img src="https://github.com/upper/db/images/gopher.svg" width="256" />
 </p>
 
-# upper.io/db.v3 [![Build Status](https://travis-ci.org/upper/db.svg?branch=master)](https://travis-ci.org/upper/db) [![GoDoc](https://godoc.org/upper.io/db.v3?status.svg)](https://godoc.org/upper.io/db.v3)
+# github.com/upper/db [![Build Status](https://travis-ci.org/upper/db.svg?branch=master)](https://travis-ci.org/upper/db) [![GoDoc](https://godoc.org/github.com/upper/db?status.svg)](https://godoc.org/github.com/upper/db)
 
-The `upper.io/db.v3` package for [Go][2] is a productive data access layer for
+The `github.com/upper/db` package for [Go][2] is a productive data access layer for
 Go that provides a common interface to work with different data sources such as
-[PostgreSQL](https://upper.io/db.v3/postgresql),
-[MySQL](https://upper.io/db.v3/mysql), [SQLite](https://upper.io/db.v3/sqlite),
-[MSSQL](https://upper.io/db.v3/mssql),
-[QL](https://upper.io/db.v3/ql) and [MongoDB](https://upper.io/db.v3/mongodb).
+[PostgreSQL](https://github.com/upper/db/postgresql),
+[MySQL](https://github.com/upper/db/mysql), [SQLite](https://github.com/upper/db/sqlite),
+[MSSQL](https://github.com/upper/db/mssql),
+[QL](https://github.com/upper/db/ql) and [MongoDB](https://github.com/upper/db/mongodb).
 
 ```
-go get upper.io/db.v3
+go get github.com/upper/db
 ```
 
 ## The tour
@@ -32,7 +32,7 @@ package main
 import (
 	"log"
 
-	"upper.io/db.v3/postgresql"
+	"github.com/upper/db/postgresql"
 )
 
 var settings = postgresql.ConnectionURL{
@@ -93,7 +93,7 @@ go run _examples/booktown-books/main.go
 
 This is the source code repository, check out our [release
 notes](https://github.com/upper/db/releases/tag/v3.0.0) and see examples and
-documentation at [upper.io/db.v3][1].
+documentation at [github.com/upper/db][1].
 
 
 ## Changelog
@@ -143,6 +143,7 @@ This project is licensed under the terms of the **MIT License**.
 * achun <<achun.shx@qq.com>>
 * rjmcguire <<rjmcguire@gmail.com>>
 * wei2912 <<wei2912_support@hotmail.com>>
+* Genert Org <<contact@genert.org>>
 
-[1]: https://upper.io/db.v3
+[1]: https://github.com/upper/db
 [2]: http://golang.org

--- a/_examples/booktown-books/main.go
+++ b/_examples/booktown-books/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"log"
 
-	"upper.io/db.v3/postgresql"
+	"github.com/upper/db/postgresql"
 )
 
 var settings = postgresql.ConnectionURL{

--- a/compound.go
+++ b/compound.go
@@ -22,7 +22,7 @@
 package db
 
 import (
-	"upper.io/db.v3/internal/immutable"
+	"github.com/upper/db/internal/immutable"
 )
 
 // Compound represents an statement that has one or many sentences joined by by

--- a/db.go
+++ b/db.go
@@ -27,7 +27,7 @@
 // driver. upper-db supports the MySQL, PostgreSQL, SQLite and QL databases and
 // provides partial support (CRUD, no transactions) for MongoDB.
 //
-//  go get upper.io/db.v3
+//  go get github.com/upper/db
 //
 // Usage
 //
@@ -36,7 +36,7 @@
 //  import (
 //  	"log"
 //
-//  	"upper.io/db.v3/postgresql" // Imports the postgresql adapter.
+//  	"github.com/upper/db/postgresql" // Imports the postgresql adapter.
 //  )
 //
 //  var settings = postgresql.ConnectionURL{
@@ -73,5 +73,5 @@
 //  }
 //
 // See more usage examples and documentation for users at
-// https://upper.io/db.v3.
-package db // import "upper.io/db.v3"
+// https://github.com/upper/db.
+package db // import "github.com/upper/db"

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/upper/db
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/lib/pq v1.0.0
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/satori/go.uuid v1.2.0
+	github.com/stretchr/testify v1.2.2
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/lib/pq v1.0.0 h1:X5PMW56eZitiTeO7tKzZxFCSpbFZJtkMMooicw2us9A=
+github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
+github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -28,7 +28,7 @@ import (
 	"strconv"
 	"sync"
 
-	"upper.io/db.v3/internal/cache/hashstructure"
+	"github.com/upper/db/internal/cache/hashstructure"
 )
 
 const defaultCapacity = 128

--- a/internal/sqladapter/collection.go
+++ b/internal/sqladapter/collection.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"reflect"
 
-	"upper.io/db.v3"
-	"upper.io/db.v3/internal/sqladapter/exql"
-	"upper.io/db.v3/lib/reflectx"
+	"github.com/upper/db"
+	"github.com/upper/db/internal/sqladapter/exql"
+	"github.com/upper/db/lib/reflectx"
 )
 
 var mapper = reflectx.NewMapper("db")

--- a/internal/sqladapter/database.go
+++ b/internal/sqladapter/database.go
@@ -9,11 +9,11 @@ import (
 	"sync/atomic"
 	"time"
 
-	"upper.io/db.v3"
-	"upper.io/db.v3/internal/cache"
-	"upper.io/db.v3/internal/sqladapter/compat"
-	"upper.io/db.v3/internal/sqladapter/exql"
-	"upper.io/db.v3/lib/sqlbuilder"
+	"github.com/upper/db"
+	"github.com/upper/db/internal/cache"
+	"github.com/upper/db/internal/sqladapter/compat"
+	"github.com/upper/db/internal/sqladapter/exql"
+	"github.com/upper/db/lib/sqlbuilder"
 )
 
 var (

--- a/internal/sqladapter/exql/default.go
+++ b/internal/sqladapter/exql/default.go
@@ -1,7 +1,7 @@
 package exql
 
 import (
-	"upper.io/db.v3/internal/cache"
+	"github.com/upper/db/internal/cache"
 )
 
 const (

--- a/internal/sqladapter/exql/hash.go
+++ b/internal/sqladapter/exql/hash.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"sync/atomic"
 
-	"upper.io/db.v3/internal/cache"
+	"github.com/upper/db/internal/cache"
 )
 
 type hash struct {

--- a/internal/sqladapter/exql/interfaces.go
+++ b/internal/sqladapter/exql/interfaces.go
@@ -1,7 +1,7 @@
 package exql
 
 import (
-	"upper.io/db.v3/internal/cache"
+	"github.com/upper/db/internal/cache"
 )
 
 // Fragment is any interface that can be both cached and compiled.

--- a/internal/sqladapter/exql/statement.go
+++ b/internal/sqladapter/exql/statement.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"strings"
 
-	"upper.io/db.v3/internal/cache"
+	"github.com/upper/db/internal/cache"
 )
 
 var errUnknownTemplateType = errors.New("Unknown template type")

--- a/internal/sqladapter/exql/template.go
+++ b/internal/sqladapter/exql/template.go
@@ -5,8 +5,8 @@ import (
 	"sync"
 	"text/template"
 
-	"upper.io/db.v3"
-	"upper.io/db.v3/internal/cache"
+	"github.com/upper/db"
+	"github.com/upper/db/internal/cache"
 )
 
 // Type is the type of SQL query the statement represents.

--- a/internal/sqladapter/result.go
+++ b/internal/sqladapter/result.go
@@ -25,9 +25,9 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"upper.io/db.v3"
-	"upper.io/db.v3/internal/immutable"
-	"upper.io/db.v3/lib/sqlbuilder"
+	"github.com/upper/db"
+	"github.com/upper/db/internal/immutable"
+	"github.com/upper/db/lib/sqlbuilder"
 )
 
 type Result struct {

--- a/internal/sqladapter/testing/adapter.go.tpl
+++ b/internal/sqladapter/testing/adapter.go.tpl
@@ -16,8 +16,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"upper.io/db.v3"
-	"upper.io/db.v3/lib/sqlbuilder"
+	"github.com/upper/db"
+	"github.com/upper/db/lib/sqlbuilder"
 )
 
 type customLogger struct {

--- a/internal/sqladapter/tx.go
+++ b/internal/sqladapter/tx.go
@@ -26,8 +26,8 @@ import (
 	"database/sql"
 	"sync/atomic"
 
-	"upper.io/db.v3"
-	"upper.io/db.v3/lib/sqlbuilder"
+	"github.com/upper/db"
+	"github.com/upper/db/lib/sqlbuilder"
 )
 
 // DatabaseTx represents a database session within a transaction.

--- a/lib/sqlbuilder/.travis.yml
+++ b/lib/sqlbuilder/.travis.yml
@@ -15,10 +15,10 @@ go:
 
 install:
   - mkdir -p $GOPATH/src/upper.io
-  - mv $PWD $GOPATH/src/upper.io/db.v3/lib/sqlbuilder
-  - cd $GOPATH/src/upper.io/db.v3/lib/sqlbuilder
+  - mv $PWD $GOPATH/src/github.com/upper/db/lib/sqlbuilder
+  - cd $GOPATH/src/github.com/upper/db/lib/sqlbuilder
   - go get -v -d -t ./...
 
 script:
-  - cd $GOPATH/src/upper.io/db.v3/lib/sqlbuilder
+  - cd $GOPATH/src/github.com/upper/db/lib/sqlbuilder
   - make test

--- a/lib/sqlbuilder/builder.go
+++ b/lib/sqlbuilder/builder.go
@@ -34,10 +34,10 @@ import (
 	"strconv"
 	"strings"
 
-	"upper.io/db.v3"
-	"upper.io/db.v3/internal/sqladapter/compat"
-	"upper.io/db.v3/internal/sqladapter/exql"
-	"upper.io/db.v3/lib/reflectx"
+	"github.com/upper/db"
+	"github.com/upper/db/internal/sqladapter/compat"
+	"github.com/upper/db/internal/sqladapter/exql"
+	"github.com/upper/db/lib/reflectx"
 )
 
 // MapOptions represents options for the mapper.

--- a/lib/sqlbuilder/builder_test.go
+++ b/lib/sqlbuilder/builder_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"upper.io/db.v3"
+	"github.com/upper/db"
 )
 
 func TestSelect(t *testing.T) {

--- a/lib/sqlbuilder/comparison.go
+++ b/lib/sqlbuilder/comparison.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"upper.io/db.v3"
-	"upper.io/db.v3/internal/sqladapter/exql"
+	"github.com/upper/db"
+	"github.com/upper/db/internal/sqladapter/exql"
 )
 
 var comparisonOperators = map[db.ComparisonOperator]string{

--- a/lib/sqlbuilder/convert.go
+++ b/lib/sqlbuilder/convert.go
@@ -5,8 +5,8 @@ import (
 	"reflect"
 	"strings"
 
-	"upper.io/db.v3"
-	"upper.io/db.v3/internal/sqladapter/exql"
+	"github.com/upper/db"
+	"github.com/upper/db/internal/sqladapter/exql"
 )
 
 var (

--- a/lib/sqlbuilder/delete.go
+++ b/lib/sqlbuilder/delete.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"database/sql"
 
-	"upper.io/db.v3/internal/immutable"
-	"upper.io/db.v3/internal/sqladapter/exql"
+	"github.com/upper/db/internal/immutable"
+	"github.com/upper/db/internal/sqladapter/exql"
 )
 
 type deleterQuery struct {

--- a/lib/sqlbuilder/fetch.go
+++ b/lib/sqlbuilder/fetch.go
@@ -24,8 +24,8 @@ package sqlbuilder
 import (
 	"reflect"
 
-	"upper.io/db.v3"
-	"upper.io/db.v3/lib/reflectx"
+	"github.com/upper/db"
+	"github.com/upper/db/lib/reflectx"
 )
 
 type hasConvertValues interface {

--- a/lib/sqlbuilder/insert.go
+++ b/lib/sqlbuilder/insert.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"database/sql"
 
-	"upper.io/db.v3/internal/immutable"
-	"upper.io/db.v3/internal/sqladapter/exql"
+	"github.com/upper/db/internal/immutable"
+	"github.com/upper/db/internal/sqladapter/exql"
 )
 
 type inserterQuery struct {

--- a/lib/sqlbuilder/interfaces.go
+++ b/lib/sqlbuilder/interfaces.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 The upper.io/db.v3/lib/sqlbuilder authors. All rights reserved.
+// Copyright (c) 2015 The github.com/upper/db/lib/sqlbuilder authors. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/lib/sqlbuilder/paginate.go
+++ b/lib/sqlbuilder/paginate.go
@@ -7,8 +7,8 @@ import (
 	"math"
 	"strings"
 
-	"upper.io/db.v3"
-	"upper.io/db.v3/internal/immutable"
+	"github.com/upper/db"
+	"github.com/upper/db/internal/immutable"
 )
 
 var (

--- a/lib/sqlbuilder/placeholder_test.go
+++ b/lib/sqlbuilder/placeholder_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"upper.io/db.v3"
+	"github.com/upper/db"
 )
 
 func TestPlaceholderSimple(t *testing.T) {

--- a/lib/sqlbuilder/scanner.go
+++ b/lib/sqlbuilder/scanner.go
@@ -24,7 +24,7 @@ package sqlbuilder
 import (
 	"database/sql"
 
-	"upper.io/db.v3"
+	"github.com/upper/db"
 )
 
 type scanner struct {

--- a/lib/sqlbuilder/select.go
+++ b/lib/sqlbuilder/select.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 	"strings"
 
-	"upper.io/db.v3"
-	"upper.io/db.v3/internal/immutable"
-	"upper.io/db.v3/internal/sqladapter/exql"
+	"github.com/upper/db"
+	"github.com/upper/db/internal/immutable"
+	"github.com/upper/db/internal/sqladapter/exql"
 )
 
 type selectorQuery struct {

--- a/lib/sqlbuilder/template.go
+++ b/lib/sqlbuilder/template.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	"upper.io/db.v3"
-	"upper.io/db.v3/internal/sqladapter/exql"
+	"github.com/upper/db"
+	"github.com/upper/db/internal/sqladapter/exql"
 )
 
 type templateWithUtils struct {

--- a/lib/sqlbuilder/template_test.go
+++ b/lib/sqlbuilder/template_test.go
@@ -1,8 +1,8 @@
 package sqlbuilder
 
 import (
-	"upper.io/db.v3/internal/cache"
-	"upper.io/db.v3/internal/sqladapter/exql"
+	"github.com/upper/db/internal/cache"
+	"github.com/upper/db/internal/sqladapter/exql"
 )
 
 const (

--- a/lib/sqlbuilder/update.go
+++ b/lib/sqlbuilder/update.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"database/sql"
 
-	"upper.io/db.v3/internal/immutable"
-	"upper.io/db.v3/internal/sqladapter/exql"
+	"github.com/upper/db/internal/immutable"
+	"github.com/upper/db/internal/sqladapter/exql"
 )
 
 type updaterQuery struct {

--- a/lib/sqlbuilder/wrapper.go
+++ b/lib/sqlbuilder/wrapper.go
@@ -27,7 +27,7 @@ import (
 	"fmt"
 	"sync"
 
-	"upper.io/db.v3"
+	"github.com/upper/db"
 )
 
 var (

--- a/mongo/README.md
+++ b/mongo/README.md
@@ -1,6 +1,6 @@
 # MongoDB adapter for upper.io/db
 
 Please read the full docs, acknowledgements and examples at
-[https://upper.io/db.v3/wrappers/mongo][1].
+[https://github.com/upper/db/wrappers/mongo][1].
 
-[1]: https://upper.io/db.v3/wrappers/mongo
+[1]: https://github.com/upper/db/wrappers/mongo

--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -30,7 +30,7 @@ import (
 
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
-	"upper.io/db.v3"
+	"github.com/upper/db"
 )
 
 // Collection represents a mongodb collection.

--- a/mongo/database.go
+++ b/mongo/database.go
@@ -20,9 +20,9 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // Package mongo wraps the gopkg.in/mgo.v2 MongoDB driver. See
-// https://upper.io/db.v3/mongo for documentation, particularities and usage
+// https://github.com/upper/db/mongo for documentation, particularities and usage
 // examples.
-package mongo // import "upper.io/db.v3/mongo"
+package mongo // import "github.com/upper/db/mongo"
 
 import (
 	"strings"
@@ -30,7 +30,7 @@ import (
 	"time"
 
 	"gopkg.in/mgo.v2"
-	"upper.io/db.v3"
+	"github.com/upper/db"
 )
 
 // Adapter holds the name of the mongodb adapter.

--- a/mongo/database_test.go
+++ b/mongo/database_test.go
@@ -34,7 +34,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/mgo.v2/bson"
-	"upper.io/db.v3"
+	"github.com/upper/db"
 )
 
 type artistType struct {

--- a/mongo/result.go
+++ b/mongo/result.go
@@ -32,9 +32,9 @@ import (
 
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
-	"upper.io/db.v3"
+	"github.com/upper/db"
 
-	"upper.io/db.v3/internal/immutable"
+	"github.com/upper/db/internal/immutable"
 )
 
 type resultQuery struct {

--- a/mssql/README.md
+++ b/mssql/README.md
@@ -1,7 +1,7 @@
 # SQLServer adapter for upper.io/db
 
 See the full docs, acknowledgements and examples at
-[https://upper.io/db.v3/mssql][1]
+[https://github.com/upper/db/mssql][1]
 
-[1]: https://upper.io/db.v3/mssql
+[1]: https://github.com/upper/db/mssql
 

--- a/mssql/adapter_test.go
+++ b/mssql/adapter_test.go
@@ -26,7 +26,7 @@ import (
 	"database/sql"
 	"os"
 
-	"upper.io/db.v3/lib/sqlbuilder"
+	"github.com/upper/db/lib/sqlbuilder"
 )
 
 const (

--- a/mssql/collection.go
+++ b/mssql/collection.go
@@ -24,9 +24,9 @@ package mssql
 import (
 	"database/sql"
 
-	"upper.io/db.v3"
-	"upper.io/db.v3/internal/sqladapter"
-	"upper.io/db.v3/lib/sqlbuilder"
+	"github.com/upper/db"
+	"github.com/upper/db/internal/sqladapter"
+	"github.com/upper/db/lib/sqlbuilder"
 )
 
 // table is the actual implementation of a collection.

--- a/mssql/database.go
+++ b/mssql/database.go
@@ -20,7 +20,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // Package mssql wraps the github.com/go-sql-driver/mssql MySQL driver. See
-// https://upper.io/db.v3/mssql for documentation, particularities and usage
+// https://github.com/upper/db/mssql for documentation, particularities and usage
 // examples.
 package mssql
 
@@ -32,11 +32,11 @@ import (
 	"database/sql"
 
 	_ "github.com/denisenkom/go-mssqldb" // MSSQL driver
-	"upper.io/db.v3"
-	"upper.io/db.v3/internal/sqladapter"
-	"upper.io/db.v3/internal/sqladapter/compat"
-	"upper.io/db.v3/internal/sqladapter/exql"
-	"upper.io/db.v3/lib/sqlbuilder"
+	"github.com/upper/db"
+	"github.com/upper/db/internal/sqladapter"
+	"github.com/upper/db/internal/sqladapter/compat"
+	"github.com/upper/db/internal/sqladapter/exql"
+	"github.com/upper/db/lib/sqlbuilder"
 )
 
 // database is the actual implementation of Database

--- a/mssql/mssql.go
+++ b/mssql/mssql.go
@@ -19,15 +19,15 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-package mssql // import "upper.io/db.v3/mssql"
+package mssql // import "github.com/upper/db/mssql"
 
 import (
 	"database/sql"
 
-	"upper.io/db.v3"
+	"github.com/upper/db"
 
-	"upper.io/db.v3/internal/sqladapter"
-	"upper.io/db.v3/lib/sqlbuilder"
+	"github.com/upper/db/internal/sqladapter"
+	"github.com/upper/db/lib/sqlbuilder"
 )
 
 const sqlDriver = `mssql`

--- a/mssql/stubs_test.go
+++ b/mssql/stubs_test.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"testing"
 
-	"upper.io/db.v3/lib/sqlbuilder"
+	"github.com/upper/db/lib/sqlbuilder"
 )
 
 func mustOpen() sqlbuilder.Database {

--- a/mssql/template.go
+++ b/mssql/template.go
@@ -22,8 +22,8 @@
 package mssql
 
 import (
-	"upper.io/db.v3/internal/cache"
-	"upper.io/db.v3/internal/sqladapter/exql"
+	"github.com/upper/db/internal/cache"
+	"github.com/upper/db/internal/sqladapter/exql"
 )
 
 const (

--- a/mssql/template_test.go
+++ b/mssql/template_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"upper.io/db.v3"
-	"upper.io/db.v3/lib/sqlbuilder"
+	"github.com/upper/db"
+	"github.com/upper/db/lib/sqlbuilder"
 )
 
 func TestTemplateSelect(t *testing.T) {

--- a/mssql/tx.go
+++ b/mssql/tx.go
@@ -24,8 +24,8 @@ package mssql
 import (
 	"context"
 
-	"upper.io/db.v3/internal/sqladapter"
-	"upper.io/db.v3/lib/sqlbuilder"
+	"github.com/upper/db/internal/sqladapter"
+	"github.com/upper/db/lib/sqlbuilder"
 )
 
 type tx struct {

--- a/mysql/README.md
+++ b/mysql/README.md
@@ -1,7 +1,7 @@
 # MySQL adapter for upper.io/db
 
 See the full docs, acknowledgements and examples at
-[https://upper.io/db.v3/mysql][1]
+[https://github.com/upper/db/mysql][1]
 
-[1]: https://upper.io/db.v3/mysql
+[1]: https://github.com/upper/db/mysql
 

--- a/mysql/adapter_test.go
+++ b/mysql/adapter_test.go
@@ -33,8 +33,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"upper.io/db.v3/internal/sqladapter"
-	"upper.io/db.v3/lib/sqlbuilder"
+	"github.com/upper/db/internal/sqladapter"
+	"github.com/upper/db/lib/sqlbuilder"
 )
 
 const (

--- a/mysql/collection.go
+++ b/mysql/collection.go
@@ -24,9 +24,9 @@ package mysql
 import (
 	"database/sql"
 
-	"upper.io/db.v3"
-	"upper.io/db.v3/internal/sqladapter"
-	"upper.io/db.v3/lib/sqlbuilder"
+	"github.com/upper/db"
+	"github.com/upper/db/internal/sqladapter"
+	"github.com/upper/db/lib/sqlbuilder"
 )
 
 // table is the actual implementation of a collection.

--- a/mysql/custom_types.go
+++ b/mysql/custom_types.go
@@ -27,7 +27,7 @@ import (
 	"errors"
 	"reflect"
 
-	"upper.io/db.v3/lib/sqlbuilder"
+	"github.com/upper/db/lib/sqlbuilder"
 )
 
 // JSON represents a MySQL's JSON value:

--- a/mysql/database.go
+++ b/mysql/database.go
@@ -20,7 +20,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // Package mysql wraps the github.com/go-sql-driver/mysql MySQL driver. See
-// https://upper.io/db.v3/mysql for documentation, particularities and usage
+// https://github.com/upper/db/mysql for documentation, particularities and usage
 // examples.
 package mysql
 
@@ -35,11 +35,11 @@ import (
 	"database/sql"
 
 	_ "github.com/go-sql-driver/mysql" // MySQL driver.
-	"upper.io/db.v3"
-	"upper.io/db.v3/internal/sqladapter"
-	"upper.io/db.v3/internal/sqladapter/compat"
-	"upper.io/db.v3/internal/sqladapter/exql"
-	"upper.io/db.v3/lib/sqlbuilder"
+	"github.com/upper/db"
+	"github.com/upper/db/internal/sqladapter"
+	"github.com/upper/db/internal/sqladapter/compat"
+	"github.com/upper/db/internal/sqladapter/exql"
+	"github.com/upper/db/lib/sqlbuilder"
 )
 
 // database is the actual implementation of Database

--- a/mysql/mysql.go
+++ b/mysql/mysql.go
@@ -19,15 +19,15 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-package mysql // import "upper.io/db.v3/mysql"
+package mysql // import "github.com/upper/db/mysql"
 
 import (
 	"database/sql"
 
-	"upper.io/db.v3"
+	"github.com/upper/db"
 
-	"upper.io/db.v3/internal/sqladapter"
-	"upper.io/db.v3/lib/sqlbuilder"
+	"github.com/upper/db/internal/sqladapter"
+	"github.com/upper/db/lib/sqlbuilder"
 )
 
 const sqlDriver = `mysql`

--- a/mysql/stubs_test.go
+++ b/mysql/stubs_test.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"testing"
 
-	"upper.io/db.v3/lib/sqlbuilder"
+	"github.com/upper/db/lib/sqlbuilder"
 )
 
 func mustOpen() sqlbuilder.Database {

--- a/mysql/template.go
+++ b/mysql/template.go
@@ -22,8 +22,8 @@
 package mysql
 
 import (
-	"upper.io/db.v3/internal/cache"
-	"upper.io/db.v3/internal/sqladapter/exql"
+	"github.com/upper/db/internal/cache"
+	"github.com/upper/db/internal/sqladapter/exql"
 )
 
 const (

--- a/mysql/template_test.go
+++ b/mysql/template_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"upper.io/db.v3"
-	"upper.io/db.v3/lib/sqlbuilder"
+	"github.com/upper/db"
+	"github.com/upper/db/lib/sqlbuilder"
 )
 
 func TestTemplateSelect(t *testing.T) {

--- a/mysql/tx.go
+++ b/mysql/tx.go
@@ -24,8 +24,8 @@ package mysql
 import (
 	"context"
 
-	"upper.io/db.v3/internal/sqladapter"
-	"upper.io/db.v3/lib/sqlbuilder"
+	"github.com/upper/db/internal/sqladapter"
+	"github.com/upper/db/lib/sqlbuilder"
 )
 
 type tx struct {

--- a/postgresql/README.md
+++ b/postgresql/README.md
@@ -1,6 +1,6 @@
 # PostgreSQL adapter for upper.io/db
 
 Please read the full docs, acknowledgements and examples at
-[https://upper.io/db.v3/postgresql][1]
+[https://github.com/upper/db/postgresql][1]
 
-[1]: https://upper.io/db.v3/postgresql
+[1]: https://github.com/upper/db/postgresql

--- a/postgresql/adapter_test.go
+++ b/postgresql/adapter_test.go
@@ -35,9 +35,9 @@ import (
 
 	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
-	"upper.io/db.v3"
-	"upper.io/db.v3/internal/sqladapter"
-	"upper.io/db.v3/lib/sqlbuilder"
+	"github.com/upper/db"
+	"github.com/upper/db/internal/sqladapter"
+	"github.com/upper/db/lib/sqlbuilder"
 )
 
 const (

--- a/postgresql/collection.go
+++ b/postgresql/collection.go
@@ -24,8 +24,8 @@ package postgresql
 import (
 	"database/sql"
 
-	"upper.io/db.v3"
-	"upper.io/db.v3/internal/sqladapter"
+	"github.com/upper/db"
+	"github.com/upper/db/internal/sqladapter"
 )
 
 // collection is the actual implementation of a collection.

--- a/postgresql/custom_types.go
+++ b/postgresql/custom_types.go
@@ -28,7 +28,7 @@ import (
 	"reflect"
 
 	"github.com/lib/pq"
-	"upper.io/db.v3/lib/sqlbuilder"
+	"github.com/upper/db/lib/sqlbuilder"
 )
 
 // Array returns a sqlbuilder.ScannerValuer for any given slice. Slice elements

--- a/postgresql/database.go
+++ b/postgresql/database.go
@@ -20,7 +20,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // Package postgresql wraps the github.com/lib/pq PostgreSQL driver. See
-// https://upper.io/db.v3/postgresql for documentation, particularities and
+// https://github.com/upper/db/postgresql for documentation, particularities and
 // usage examples.
 package postgresql
 
@@ -35,11 +35,11 @@ import (
 	"time"
 
 	_ "github.com/lib/pq" // PostgreSQL driver.
-	"upper.io/db.v3"
-	"upper.io/db.v3/internal/sqladapter"
-	"upper.io/db.v3/internal/sqladapter/compat"
-	"upper.io/db.v3/internal/sqladapter/exql"
-	"upper.io/db.v3/lib/sqlbuilder"
+	"github.com/upper/db"
+	"github.com/upper/db/internal/sqladapter"
+	"github.com/upper/db/internal/sqladapter/compat"
+	"github.com/upper/db/internal/sqladapter/exql"
+	"github.com/upper/db/lib/sqlbuilder"
 )
 
 // database is the actual implementation of Database

--- a/postgresql/local_test.go
+++ b/postgresql/local_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"upper.io/db.v3"
+	"github.com/upper/db"
 )
 
 func TestStringAndInt64Array(t *testing.T) {

--- a/postgresql/postgresql.go
+++ b/postgresql/postgresql.go
@@ -19,15 +19,15 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-package postgresql // import "upper.io/db.v3/postgresql"
+package postgresql // import "github.com/upper/db/postgresql"
 
 import (
 	"database/sql"
 
-	"upper.io/db.v3"
+	"github.com/upper/db"
 
-	"upper.io/db.v3/internal/sqladapter"
-	"upper.io/db.v3/lib/sqlbuilder"
+	"github.com/upper/db/internal/sqladapter"
+	"github.com/upper/db/lib/sqlbuilder"
 )
 
 const sqlDriver = `postgres`

--- a/postgresql/stubs_test.go
+++ b/postgresql/stubs_test.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"testing"
 
-	"upper.io/db.v3/lib/sqlbuilder"
+	"github.com/upper/db/lib/sqlbuilder"
 )
 
 func mustOpen() sqlbuilder.Database {

--- a/postgresql/template.go
+++ b/postgresql/template.go
@@ -22,9 +22,9 @@
 package postgresql
 
 import (
-	"upper.io/db.v3"
-	"upper.io/db.v3/internal/cache"
-	"upper.io/db.v3/internal/sqladapter/exql"
+	"github.com/upper/db"
+	"github.com/upper/db/internal/cache"
+	"github.com/upper/db/internal/sqladapter/exql"
 )
 
 const (

--- a/postgresql/template_test.go
+++ b/postgresql/template_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"upper.io/db.v3"
-	"upper.io/db.v3/lib/sqlbuilder"
+	"github.com/upper/db"
+	"github.com/upper/db/lib/sqlbuilder"
 )
 
 func TestTemplateSelect(t *testing.T) {

--- a/postgresql/tx.go
+++ b/postgresql/tx.go
@@ -24,8 +24,8 @@ package postgresql
 import (
 	"context"
 
-	"upper.io/db.v3/internal/sqladapter"
-	"upper.io/db.v3/lib/sqlbuilder"
+	"github.com/upper/db/internal/sqladapter"
+	"github.com/upper/db/lib/sqlbuilder"
 )
 
 type tx struct {

--- a/ql/adapter_test.go
+++ b/ql/adapter_test.go
@@ -26,7 +26,7 @@ import (
 	"database/sql"
 	"os"
 
-	"upper.io/db.v3/lib/sqlbuilder"
+	"github.com/upper/db/lib/sqlbuilder"
 )
 
 const (

--- a/ql/collection.go
+++ b/ql/collection.go
@@ -24,9 +24,9 @@ package ql
 import (
 	"database/sql"
 
-	"upper.io/db.v3"
-	"upper.io/db.v3/internal/sqladapter"
-	"upper.io/db.v3/lib/sqlbuilder"
+	"github.com/upper/db"
+	"github.com/upper/db/internal/sqladapter"
+	"github.com/upper/db/lib/sqlbuilder"
 )
 
 // table is the actual implementation of a collection.

--- a/ql/database.go
+++ b/ql/database.go
@@ -20,7 +20,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // Package ql wraps the github.com/cznic/ql/driver QL driver. See
-// https://upper.io/db.v3/ql for documentation, particularities and usage
+// https://github.com/upper/db/ql for documentation, particularities and usage
 // examples.
 package ql
 
@@ -33,11 +33,11 @@ import (
 	"sync/atomic"
 
 	_ "github.com/cznic/ql/driver" // QL driver
-	"upper.io/db.v3"
-	"upper.io/db.v3/internal/sqladapter"
-	"upper.io/db.v3/internal/sqladapter/compat"
-	"upper.io/db.v3/internal/sqladapter/exql"
-	"upper.io/db.v3/lib/sqlbuilder"
+	"github.com/upper/db"
+	"github.com/upper/db/internal/sqladapter"
+	"github.com/upper/db/internal/sqladapter/compat"
+	"github.com/upper/db/internal/sqladapter/exql"
+	"github.com/upper/db/lib/sqlbuilder"
 )
 
 // database is the actual implementation of Database

--- a/ql/ql.go
+++ b/ql/ql.go
@@ -19,10 +19,10 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-package ql // import "upper.io/db.v3/ql"
+package ql // import "github.com/upper/db/ql"
 
 import (
-	"upper.io/db.v3/lib/sqlbuilder"
+	"github.com/upper/db/lib/sqlbuilder"
 )
 
 const sqlDriver = `ql`

--- a/ql/stubs_test.go
+++ b/ql/stubs_test.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"testing"
 
-	"upper.io/db.v3/lib/sqlbuilder"
+	"github.com/upper/db/lib/sqlbuilder"
 )
 
 func mustOpen() sqlbuilder.Database {

--- a/ql/template.go
+++ b/ql/template.go
@@ -22,9 +22,9 @@
 package ql
 
 import (
-	"upper.io/db.v3"
-	"upper.io/db.v3/internal/cache"
-	"upper.io/db.v3/internal/sqladapter/exql"
+	"github.com/upper/db"
+	"github.com/upper/db/internal/cache"
+	"github.com/upper/db/internal/sqladapter/exql"
 )
 
 const (

--- a/ql/template_test.go
+++ b/ql/template_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"upper.io/db.v3"
-	"upper.io/db.v3/lib/sqlbuilder"
+	"github.com/upper/db"
+	"github.com/upper/db/lib/sqlbuilder"
 )
 
 func TestTemplateSelect(t *testing.T) {

--- a/ql/tx.go
+++ b/ql/tx.go
@@ -24,8 +24,8 @@ package ql
 import (
 	"context"
 
-	"upper.io/db.v3/internal/sqladapter"
-	"upper.io/db.v3/lib/sqlbuilder"
+	"github.com/upper/db/internal/sqladapter"
+	"github.com/upper/db/lib/sqlbuilder"
 )
 
 type tx struct {

--- a/sqlite/README.md
+++ b/sqlite/README.md
@@ -1,6 +1,6 @@
 # SQLite3 adapter for upper.io/db
 
 Please read the full docs, acknowledgements and examples at
-[https://upper.io/db.v3/sqlite][1]
+[https://github.com/upper/db/sqlite][1]
 
-[1]: https://upper.io/db.v3/sqlite
+[1]: https://github.com/upper/db/sqlite

--- a/sqlite/adapter_test.go
+++ b/sqlite/adapter_test.go
@@ -26,7 +26,7 @@ import (
 	"database/sql"
 	"os"
 
-	"upper.io/db.v3/lib/sqlbuilder"
+	"github.com/upper/db/lib/sqlbuilder"
 )
 
 const (

--- a/sqlite/collection.go
+++ b/sqlite/collection.go
@@ -24,9 +24,9 @@ package sqlite
 import (
 	"database/sql"
 
-	"upper.io/db.v3"
-	"upper.io/db.v3/internal/sqladapter"
-	"upper.io/db.v3/lib/sqlbuilder"
+	"github.com/upper/db"
+	"github.com/upper/db/internal/sqladapter"
+	"github.com/upper/db/lib/sqlbuilder"
 )
 
 // table is the actual implementation of a collection.

--- a/sqlite/database.go
+++ b/sqlite/database.go
@@ -20,7 +20,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // Package sqlite wraps the github.com/lib/sqlite SQLite driver. See
-// https://upper.io/db.v3/sqlite for documentation, particularities and
+// https://github.com/upper/db/sqlite for documentation, particularities and
 // usage examples.
 package sqlite
 
@@ -33,11 +33,11 @@ import (
 	"sync/atomic"
 
 	_ "github.com/mattn/go-sqlite3" // SQLite3 driver.
-	"upper.io/db.v3"
-	"upper.io/db.v3/internal/sqladapter"
-	"upper.io/db.v3/internal/sqladapter/compat"
-	"upper.io/db.v3/internal/sqladapter/exql"
-	"upper.io/db.v3/lib/sqlbuilder"
+	"github.com/upper/db"
+	"github.com/upper/db/internal/sqladapter"
+	"github.com/upper/db/internal/sqladapter/compat"
+	"github.com/upper/db/internal/sqladapter/exql"
+	"github.com/upper/db/lib/sqlbuilder"
 )
 
 // database is the actual implementation of Database

--- a/sqlite/sqlite.go
+++ b/sqlite/sqlite.go
@@ -19,15 +19,15 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-package sqlite // import "upper.io/db.v3/sqlite"
+package sqlite // import "github.com/upper/db/sqlite"
 
 import (
 	"database/sql"
 
-	"upper.io/db.v3"
+	"github.com/upper/db"
 
-	"upper.io/db.v3/internal/sqladapter"
-	"upper.io/db.v3/lib/sqlbuilder"
+	"github.com/upper/db/internal/sqladapter"
+	"github.com/upper/db/lib/sqlbuilder"
 )
 
 const sqlDriver = `sqlite`

--- a/sqlite/stubs_test.go
+++ b/sqlite/stubs_test.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"testing"
 
-	"upper.io/db.v3/lib/sqlbuilder"
+	"github.com/upper/db/lib/sqlbuilder"
 )
 
 func mustOpen() sqlbuilder.Database {

--- a/sqlite/template.go
+++ b/sqlite/template.go
@@ -22,8 +22,8 @@
 package sqlite
 
 import (
-	"upper.io/db.v3/internal/cache"
-	"upper.io/db.v3/internal/sqladapter/exql"
+	"github.com/upper/db/internal/cache"
+	"github.com/upper/db/internal/sqladapter/exql"
 )
 
 const (

--- a/sqlite/template_test.go
+++ b/sqlite/template_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"upper.io/db.v3"
-	"upper.io/db.v3/lib/sqlbuilder"
+	"github.com/upper/db"
+	"github.com/upper/db/lib/sqlbuilder"
 )
 
 func TestTemplateSelect(t *testing.T) {

--- a/sqlite/tx.go
+++ b/sqlite/tx.go
@@ -24,8 +24,8 @@ package sqlite
 import (
 	"context"
 
-	"upper.io/db.v3/internal/sqladapter"
-	"upper.io/db.v3/lib/sqlbuilder"
+	"github.com/upper/db/internal/sqladapter"
+	"github.com/upper/db/lib/sqlbuilder"
 )
 
 type tx struct {

--- a/tests/db_test.go
+++ b/tests/db_test.go
@@ -34,13 +34,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
-	"upper.io/db.v3"
-	"upper.io/db.v3/mongo"
-	"upper.io/db.v3/mssql"
-	"upper.io/db.v3/mysql"
-	"upper.io/db.v3/postgresql"
-	"upper.io/db.v3/ql"
-	"upper.io/db.v3/sqlite"
+	"github.com/upper/db"
+	"github.com/upper/db/mongo"
+	"github.com/upper/db/mssql"
+	"github.com/upper/db/mysql"
+	"github.com/upper/db/postgresql"
+	"github.com/upper/db/ql"
+	"github.com/upper/db/sqlite"
 )
 
 var wrappers = []string{


### PR DESCRIPTION
In reference to #463 and #424 , this PR will change module path to github.com instead and also add Go modules support.