### PR TITLE
add SetColumn to sqlbuilder interface, export setColumns

### DIFF
--- a/lib/sqlbuilder/interfaces.go
+++ b/lib/sqlbuilder/interfaces.go
@@ -185,6 +185,14 @@ type Selector interface {
 	//   s.Columns(sqlbuilder.Func("DATABASE_NAME"))
 	Columns(columns ...interface{}) Selector
 
+	// SetColumns overrides previously selected columns
+	//
+	// Using SetColumns will replace any previously selected columns.
+	//
+	//   s.Columns("name", "last_name").SetColumns("first_name")
+	//
+	SetColumns(columns ...interface{}) Selector
+
 	// From represents a FROM clause and is tipically used after Columns().
 	//
 	// FROM defines from which table data is going to be retrieved

--- a/lib/sqlbuilder/select.go
+++ b/lib/sqlbuilder/select.go
@@ -162,6 +162,10 @@ func (sel *selector) setColumns(columns ...interface{}) Selector {
 	})
 }
 
+func (sel *selector) SetColumns(columns ...interface{}) Selector {
+	return sel.setColumns(columns...)
+}
+
 func (sel *selector) Columns(columns ...interface{}) Selector {
 	return sel.frame(func(sq *selectorQuery) error {
 		return sq.pushColumns(columns...)


### PR DESCRIPTION
Per Issue #454.

This opens up possibility for modification of a selector query.

My use case is building a sudo-graphql api where some base query's "selects" may change on the fly via given request parameters.