### PR TITLE
Improve documentation for db.Raw, db.Func

### DIFF
--- a/lib/sqlbuilder/interfaces.go
+++ b/lib/sqlbuilder/interfaces.go
@@ -201,7 +201,7 @@ type Selector interface {
 	//   s.Columns(...).From("people p").Where("p.name = ?", ...)
 	From(tables ...interface{}) Selector
 
-	// Distict represents a DISCTINCT clause
+	// Distict represents a DISTINCT clause
 	//
 	// DISTINCT is used to ask the database to return only values that are
 	// different.  Use it instead of the .Columns() method.

--- a/lib/sqlbuilder/interfaces.go
+++ b/lib/sqlbuilder/interfaces.go
@@ -175,14 +175,14 @@ type Selector interface {
 	//
 	//   s.Columns("name n")
 	//
-	// If you don't want the column to be escaped use the sqlbuilder.RawString
+	// If you don't want the column to be escaped use the db.Raw
 	// function.
 	//
-	//   s.Columns(sqlbuilder.RawString("DATABASE_NAME()"))
+	//   s.Columns(db.Raw("MAX(id)"))
 	//
 	// The above statement is equivalent to:
 	//
-	//   s.Columns(sqlbuilder.Func("DATABASE_NAME"))
+	//   s.Columns(db.Func("MAX", "id"))
 	Columns(columns ...interface{}) Selector
 
 	// From represents a FROM clause and is tipically used after Columns().
@@ -203,8 +203,8 @@ type Selector interface {
 
 	// Distict represents a DISCTINCT clause
 	//
-	// DISCTINC is used to ask the database to return only values that are
-	// different.
+	// DISTINCT is used to ask the database to return only values that are
+	// different.  Use it instead of the .Columns() method.
 	Distinct(columns ...interface{}) Selector
 
 	// As defines an alias for a table.

--- a/lib/sqlbuilder/interfaces.go
+++ b/lib/sqlbuilder/interfaces.go
@@ -204,7 +204,7 @@ type Selector interface {
 	// Distict represents a DISTINCT clause
 	//
 	// DISTINCT is used to ask the database to return only values that are
-	// different.  Use it instead of the .Columns() method.
+	// different.
 	Distinct(columns ...interface{}) Selector
 
 	// As defines an alias for a table.


### PR DESCRIPTION
I ran into a part in the godoc where it refers to `sqlbuilder.Raw` and `sqlbuilder.Func`, but these have been moved into the main `db` package.  I was only able to figure this out using #372 so I wanted to update the docs to reflect the current usage.

While I was in there I corrected some typos in the `Distinct` section.