### PR TITLE
Fixes ParseUrl()'s check to better differentiate between URI and key/value

### DIFF
--- a/postgresql/connection.go
+++ b/postgresql/connection.go
@@ -164,7 +164,7 @@ func (c ConnectionURL) String() (s string) {
 func ParseURL(s string) (u ConnectionURL, err error) {
 	o := make(values)
 
-	if strings.HasPrefix(s, "postgres://") {
+	if strings.HasPrefix(s, "postgres://") || strings.HasPrefix(s, "postgresql://") {
 		s, err = pq.ParseURL(s)
 		if err != nil {
 			return u, err


### PR DESCRIPTION
Better differentiation between URI ("postgres://...") and key/value ("host=postgres user=postgres ...") connection strings.

Section 33.1.1.2. Connection URIs clearly states it can either be "postgres://" or "postgresql://" whilst the current check is only for the first.
https://www.postgresql.org/docs/current/libpq-connect.html