### PR TITLE
Use id.ID() in save creation to work with uuids

### DIFF
--- a/internal/sqladapter/collection.go
+++ b/internal/sqladapter/collection.go
@@ -211,7 +211,7 @@ func (c *collection) InsertReturning(item interface{}) error {
 	} else {
 		// We have one primary key, build a explicit db.Cond with it to prevent
 		// string keys to be considered as raw conditions.
-		newItemRes = col.Find(db.Cond{pks[0]: id}) // We already checked that pks is not empty, so pks[0] is defined.
+		newItemRes = col.Find(db.Cond{pks[0]: id.ID()}) // We already checked that pks is not empty, so pks[0] is defined.
 	}
 
 	// Fetch the row that was just interted into newItem


### PR DESCRIPTION
Since uuids raw are byte arrays, the query for the inserted item will fail. This makes it impossible to save a record with a uuid (string) primary key

The argument passed will be `[]interface {}{(*db.InsertResult)(0xc00041c070)}`  and the error will be `incorrect binary data format` 
