### PR TITLE
Add test for "incorrect binary format" issue

### DIFF
--- a/adapter/mongo/collection.go
+++ b/adapter/mongo/collection.go
@@ -267,7 +267,7 @@ func (col *Collection) UpdateReturning(item interface{}) error {
 }
 
 // Insert inserts a record (map or struct) into the collection.
-func (col *Collection) Insert(item interface{}) (*db.InsertResult, error) {
+func (col *Collection) Insert(item interface{}) (db.InsertResult, error) {
 	var err error
 
 	id := getID(item)

--- a/adapter/postgresql/Makefile
+++ b/adapter/postgresql/Makefile
@@ -2,6 +2,7 @@ SHELL					        ?= bash
 
 POSTGRES_VERSION      ?= 11-alpine
 POSTGRES_SUPPORTED    ?= 13-alpine 12-alpine $(POSTGRES_VERSION) 10-alpine 9-alpine
+
 PROJECT               ?= upper_postgres_$(POSTGRES_VERSION)
 
 DB_HOST               ?= 127.0.0.1

--- a/adapter/postgresql/helper_test.go
+++ b/adapter/postgresql/helper_test.go
@@ -244,6 +244,14 @@ func (h *Helper) TearUp() error {
 			name VARCHAR(25)
 		)`,
 
+		`CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`,
+
+		`DROP TABLE IF EXISTS auto_uuid_records`,
+		`CREATE TABLE auto_uuid_records (
+			id UUID PRIMARY KEY NOT NULL DEFAULT uuid_generate_v4(),
+			name VARCHAR(25)
+		)`,
+
 		`DROP TABLE IF EXISTS issue_370_2`,
 		`CREATE TABLE issue_370_2 (
 			id INTEGER[3] PRIMARY KEY,

--- a/adapter/postgresql/helper_test.go
+++ b/adapter/postgresql/helper_test.go
@@ -248,8 +248,10 @@ func (h *Helper) TearUp() error {
 
 		`DROP TABLE IF EXISTS auto_uuid_records`,
 		`CREATE TABLE auto_uuid_records (
-			id UUID PRIMARY KEY NOT NULL DEFAULT uuid_generate_v4(),
-			name VARCHAR(25)
+			name character varying(256) NOT NULL,
+			created_at timestamp without time zone DEFAULT now() NOT NULL,
+			updated_at timestamp without time zone DEFAULT now() NOT NULL,
+			id uuid PRIMARY KEY NOT NULL DEFAULT public.uuid_generate_v4()
 		)`,
 
 		`DROP TABLE IF EXISTS issue_370_2`,

--- a/adapter/postgresql/helper_test.go
+++ b/adapter/postgresql/helper_test.go
@@ -246,13 +246,15 @@ func (h *Helper) TearUp() error {
 
 		`CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`,
 
-		`DROP TABLE IF EXISTS auto_uuid_records`,
-		`CREATE TABLE auto_uuid_records (
+		`DROP TABLE IF EXISTS issue_602_organizations`,
+		`CREATE TABLE issue_602_organizations (
 			name character varying(256) NOT NULL,
 			created_at timestamp without time zone DEFAULT now() NOT NULL,
 			updated_at timestamp without time zone DEFAULT now() NOT NULL,
-			id uuid PRIMARY KEY NOT NULL DEFAULT public.uuid_generate_v4()
+			id uuid DEFAULT public.uuid_generate_v4() NOT NULL
 		)`,
+
+		`ALTER TABLE ONLY issue_602_organizations ADD CONSTRAINT issue_602_organizations_pkey PRIMARY KEY (id)`,
 
 		`DROP TABLE IF EXISTS issue_370_2`,
 		`CREATE TABLE issue_370_2 (

--- a/adapter/postgresql/helper_test.go
+++ b/adapter/postgresql/helper_test.go
@@ -236,6 +236,8 @@ func (h *Helper) TearUp() error {
 			, varchar_value_ptr varchar(64)
 			, decimal_value_ptr decimal
 
+			, uuid_value_string UUID
+
 		)`,
 
 		`DROP TABLE IF EXISTS issue_370`,

--- a/adapter/postgresql/postgresql_test.go
+++ b/adapter/postgresql/postgresql_test.go
@@ -898,6 +898,62 @@ func (s *AdapterTests) Test_Issue370_InsertUUID() {
 	}
 }
 
+type uuidRecord struct {
+	ID   string `db:"id,omitempty"`
+	Name string `db:"name"`
+}
+
+func (r *uuidRecord) Store(sess db.Session) db.Store {
+	return sess.Collection("auto_uuid_records")
+}
+
+func (s *AdapterTests) TestIncorrectBinaryFormat() {
+	sess := s.Session()
+
+	{
+		item1 := uuidRecord{
+			Name: "Jonny",
+		}
+
+		col := sess.Collection("auto_uuid_records")
+		err := col.Truncate()
+		s.NoError(err)
+
+		err = col.InsertReturning(&item1)
+		s.NoError(err)
+	}
+
+	{
+		newUUID := uuid.New()
+
+		item1 := uuidRecord{
+			ID:   newUUID.String(),
+			Name: "Jonny",
+		}
+
+		col := sess.Collection("auto_uuid_records")
+		err := col.Truncate()
+		s.NoError(err)
+
+		id, err := col.Insert(item1)
+		s.NoError(err)
+		s.NotZero(id)
+	}
+
+	{
+		item1 := uuidRecord{
+			Name: "Jonny",
+		}
+
+		col := sess.Collection("auto_uuid_records")
+		err := col.Truncate()
+		s.NoError(err)
+
+		err = sess.Save(&item1)
+		s.NoError(err)
+	}
+}
+
 func (s *AdapterTests) TestInsertVarcharPrimaryKey() {
 	sess := s.Session()
 

--- a/adapter/postgresql/postgresql_test.go
+++ b/adapter/postgresql/postgresql_test.go
@@ -923,7 +923,21 @@ var _ interface {
 } = &issue602Organization{}
 
 func (s *AdapterTests) TestIncorrectBinaryFormat() {
-	sess := s.Session()
+	settingsWithBinaryMode := ConnectionURL{
+		Database: settings.Database,
+		User:     settings.User,
+		Password: settings.Password,
+		Host:     settings.Host,
+		Options: map[string]string{
+			"timezone":          testsuite.TimeZone,
+			"binary_parameters": "yes",
+		},
+	}
+
+	sess, err := Open(settingsWithBinaryMode)
+	if err != nil {
+		s.T().Errorf("%v", err)
+	}
 
 	{
 		item := issue602Organization{

--- a/adapter/postgresql/postgresql_test.go
+++ b/adapter/postgresql/postgresql_test.go
@@ -899,13 +899,19 @@ func (s *AdapterTests) Test_Issue370_InsertUUID() {
 }
 
 type uuidRecord struct {
-	ID   string `db:"id,omitempty"`
-	Name string `db:"name"`
+	ID        string    `json:"id" db:"id,omitempty"`
+	Name      string    `json:"name" db:"name"`
+	CreatedAt time.Time `json:"created_at,omitempty" db:"created_at,omitempty"`
+	UpdatedAt time.Time `json:"updated_at,omitempty" db:"updated_at,omitempty"`
 }
 
 func (r *uuidRecord) Store(sess db.Session) db.Store {
 	return sess.Collection("auto_uuid_records")
 }
+
+var _ interface {
+	db.Record
+} = &uuidRecord{}
 
 func (s *AdapterTests) TestIncorrectBinaryFormat() {
 	sess := s.Session()

--- a/adapter/postgresql/postgresql_test.go
+++ b/adapter/postgresql/postgresql_test.go
@@ -258,11 +258,15 @@ func testPostgreSQLTypes(t *testing.T, sess db.Session) {
 		IntegerValuePtr *int64   `db:"integer_value_ptr,omitempty"`
 		VarcharValuePtr *string  `db:"varchar_value_ptr,omitempty"`
 		DecimalValuePtr *float64 `db:"decimal_value_ptr,omitempty"`
+
+		UUIDValueString *string `db:"uuid_value_string,omitempty"`
 	}
 
 	integerValue := int64(10)
 	stringValue := string("ten")
 	decimalValue := float64(10.0)
+
+	uuidStringValue := "52356d08-6a16-4839-9224-75f0a547e13c"
 
 	integerArrayValue := Int64Array{1, 2, 3, 4}
 	stringArrayValue := StringArray{"a", "b", "c"}
@@ -271,6 +275,9 @@ func testPostgreSQLTypes(t *testing.T, sess db.Session) {
 	testValue := "Hello world!"
 
 	origPgTypeTests := []PGType{
+		PGType{
+			UUIDValueString: &uuidStringValue,
+		},
 		PGType{
 			UInt8Value:      7,
 			UInt8ValueArray: uint8CompatArray{1, 2, 3, 4, 5, 6},
@@ -922,7 +929,7 @@ var _ interface {
 	db.BeforeUpdateHook
 } = &issue602Organization{}
 
-func (s *AdapterTests) TestIncorrectBinaryFormat() {
+func (s *AdapterTests) Test_Issue602_IncorrectBinaryFormat() {
 	settingsWithBinaryMode := ConnectionURL{
 		Database: settings.Database,
 		User:     settings.User,

--- a/adapter/postgresql/postgresql_test.go
+++ b/adapter/postgresql/postgresql_test.go
@@ -898,64 +898,86 @@ func (s *AdapterTests) Test_Issue370_InsertUUID() {
 	}
 }
 
-type uuidRecord struct {
+type issue602Organization struct {
 	ID        string    `json:"id" db:"id,omitempty"`
 	Name      string    `json:"name" db:"name"`
 	CreatedAt time.Time `json:"created_at,omitempty" db:"created_at,omitempty"`
 	UpdatedAt time.Time `json:"updated_at,omitempty" db:"updated_at,omitempty"`
 }
 
-func (r *uuidRecord) Store(sess db.Session) db.Store {
-	return sess.Collection("auto_uuid_records")
+type issue602OrganizationStore struct {
+	db.Store
+}
+
+func (r *issue602Organization) BeforeUpdate(db.Session) error {
+	return nil
+}
+
+func (r *issue602Organization) Store(sess db.Session) db.Store {
+	return issue602OrganizationStore{sess.Collection("issue_602_organizations")}
 }
 
 var _ interface {
 	db.Record
-} = &uuidRecord{}
+	db.BeforeUpdateHook
+} = &issue602Organization{}
 
 func (s *AdapterTests) TestIncorrectBinaryFormat() {
 	sess := s.Session()
 
 	{
-		item1 := uuidRecord{
+		item := issue602Organization{
 			Name: "Jonny",
 		}
 
-		col := sess.Collection("auto_uuid_records")
+		col := sess.Collection("issue_602_organizations")
 		err := col.Truncate()
 		s.NoError(err)
 
-		err = col.InsertReturning(&item1)
+		err = sess.Save(&item)
+		s.NoError(err)
+	}
+
+	{
+		item := issue602Organization{
+			Name: "Jonny",
+		}
+
+		col := sess.Collection("issue_602_organizations")
+		err := col.Truncate()
+		s.NoError(err)
+
+		err = col.InsertReturning(&item)
 		s.NoError(err)
 	}
 
 	{
 		newUUID := uuid.New()
 
-		item1 := uuidRecord{
+		item := issue602Organization{
 			ID:   newUUID.String(),
 			Name: "Jonny",
 		}
 
-		col := sess.Collection("auto_uuid_records")
+		col := sess.Collection("issue_602_organizations")
 		err := col.Truncate()
 		s.NoError(err)
 
-		id, err := col.Insert(item1)
+		id, err := col.Insert(item)
 		s.NoError(err)
 		s.NotZero(id)
 	}
 
 	{
-		item1 := uuidRecord{
+		item := issue602Organization{
 			Name: "Jonny",
 		}
 
-		col := sess.Collection("auto_uuid_records")
+		col := sess.Collection("issue_602_organizations")
 		err := col.Truncate()
 		s.NoError(err)
 
-		err = sess.Save(&item1)
+		err = sess.Save(&item)
 		s.NoError(err)
 	}
 }

--- a/collection.go
+++ b/collection.go
@@ -43,7 +43,7 @@ type Collection interface {
 	// on both the database adapter and the column storing the ID.  The ID
 	// returned by Insert() could be passed directly to Find() to retrieve the
 	// newly added element.
-	Insert(interface{}) (*InsertResult, error)
+	Insert(interface{}) (InsertResult, error)
 
 	// InsertReturning is like Insert() but it takes a pointer to map or struct
 	// and, if the operation succeeds, updates it with data from the newly

--- a/errors.go
+++ b/errors.go
@@ -55,7 +55,7 @@ var (
 	ErrUnsupportedValue         = errors.New(`upper: value does not support unmarshaling`)
 	ErrNilRecord                = errors.New(`upper: invalid item (nil)`)
 	ErrRecordIDIsZero           = errors.New(`upper: item ID is not defined`)
-	ErrMissingPrimaryKeys       = errors.New(`upper: collection has no primary keys`)
+	ErrMissingPrimaryKeys       = errors.New(`upper: collection %q has no primary keys`)
 	ErrWarnSlowQuery            = errors.New(`upper: slow query`)
 	ErrTransactionAborted       = errors.New(`upper: transaction was aborted`)
 	ErrNotWithinTransaction     = errors.New(`upper: not within transaction`)

--- a/internal/adapter/constraint.go
+++ b/internal/adapter/constraint.go
@@ -21,6 +21,11 @@
 
 package adapter
 
+// ConstraintValuer allows constraints to use specific values of their own.
+type ConstraintValuer interface {
+	ConstraintValue() interface{}
+}
+
 // Constraint interface represents a single condition, like "a = 1".  where `a`
 // is the key and `1` is the value. This is an exported interface but it's
 // rarely used directly, you may want to use the `db.Cond{}` map instead.
@@ -51,6 +56,9 @@ func (c constraint) Key() interface{} {
 }
 
 func (c constraint) Value() interface{} {
+	if constraintValuer, ok := c.v.(ConstraintValuer); ok {
+		return constraintValuer.ConstraintValue()
+	}
 	return c.v
 }
 

--- a/internal/sqladapter/collection.go
+++ b/internal/sqladapter/collection.go
@@ -20,7 +20,7 @@ type CollectionAdapter interface {
 // Collection satisfies db.Collection.
 type Collection interface {
 	// Insert inserts a new item into the collection.
-	Insert(interface{}) (*db.InsertResult, error)
+	Insert(interface{}) (db.InsertResult, error)
 
 	// Name returns the name of the collection.
 	Name() string
@@ -102,7 +102,7 @@ func (c *collection) Count() (uint64, error) {
 	return c.Find().Count()
 }
 
-func (c *collection) Insert(item interface{}) (*db.InsertResult, error) {
+func (c *collection) Insert(item interface{}) (db.InsertResult, error) {
 	id, err := c.adapter.Insert(c, item)
 	if err != nil {
 		return nil, err
@@ -211,7 +211,7 @@ func (c *collection) InsertReturning(item interface{}) error {
 	} else {
 		// We have one primary key, build a explicit db.Cond with it to prevent
 		// string keys to be considered as raw conditions.
-		newItemRes = col.Find(db.Cond{pks[0]: id.ID()}) // We already checked that pks is not empty, so pks[0] is defined.
+		newItemRes = col.Find(db.Cond{pks[0]: id}) // We already checked that pks is not empty, so pks[0] is defined.
 	}
 
 	// Fetch the row that was just interted into newItem

--- a/internal/sqlbuilder/template.go
+++ b/internal/sqlbuilder/template.go
@@ -128,7 +128,7 @@ func (tu *templateWithUtils) toWhereWithArguments(term interface{}) (where exql.
 		where.Conditions = append(where.Conditions, frag)
 		return
 
-	case *db.InsertResult:
+	case db.InsertResult:
 		return tu.toWhereWithArguments(t.ID())
 
 	case adapter.Constraint:

--- a/result.go
+++ b/result.go
@@ -180,24 +180,35 @@ type Result interface {
 }
 
 // InsertResult provides infomation about an insert operation.
-type InsertResult struct {
+type InsertResult interface {
+	// ID returns the ID of the newly inserted record.
+	ID() ID
+}
+
+type insertResult struct {
 	id interface{}
 }
 
-// ID returns the ID of the newly inserted record.
-func (r *InsertResult) ID() ID {
+func (r *insertResult) ID() ID {
+	return r.id
+}
+
+// ConstraintValue satisfies adapter.ConstraintValuer
+func (r *insertResult) ConstraintValue() interface{} {
 	return r.id
 }
 
 // Value satisfies driver.Valuer
-func (r InsertResult) Value() (driver.Value, error) {
+func (r *insertResult) Value() (driver.Value, error) {
 	return r.id, nil
 }
 
 // NewInsertResult creates an InsertResult
-func NewInsertResult(id interface{}) *InsertResult {
-	return &InsertResult{id: id}
+func NewInsertResult(id interface{}) InsertResult {
+	return &insertResult{id: id}
 }
 
 // ID represents a record ID
 type ID interface{}
+
+var _ = driver.Valuer(&insertResult{})


### PR DESCRIPTION
This test should reproduce the following case https://github.com/upper/db/pull/602, the problem here was that a `[]byte` value was making its way to a query and that caused trouble when working with `binary_parameters=yes` (see https://github.com/upper/db/pull/602#issuecomment-754261780), with this change the `[]byte` value is going to be converted into a `string`, which is properly encoded by `lib/pq`.