### PR TITLE
Add Limit(1) to One()

### DIFF
--- a/internal/sqladapter/result.go
+++ b/internal/sqladapter/result.go
@@ -234,13 +234,14 @@ func (r *Result) All(dst interface{}) error {
 
 // One fetches only one Result from the set.
 func (r *Result) One(dst interface{}) error {
-	query, err := r.buildPaginator()
+	one := r.Limit(1).(*Result)
+	query, err := one.buildPaginator()
 	if err != nil {
-		r.setErr(err)
+		one.setErr(err)
 		return err
 	}
 	err = query.Iterator().One(dst)
-	r.setErr(err)
+	one.setErr(err)
 	return err
 }
 

--- a/internal/testsuite/sql_suite.go
+++ b/internal/testsuite/sql_suite.go
@@ -127,7 +127,7 @@ func (s *SQLTestSuite) TestPreparedStatementsCache() {
 			// prepared statement everytime it's called.
 			res := sess.Collection("artist").
 				Find().
-				Select(db.Raw(fmt.Sprintf("count(%d)", i)))
+				Select(db.Raw(fmt.Sprintf("count(%d) AS c", i)))
 
 			var count map[string]uint64
 			err := res.One(&count)

--- a/mssql/Makefile
+++ b/mssql/Makefile
@@ -1,7 +1,7 @@
 SHELL					        := bash
 
-MSSQL_VERSION         ?= 2017-latest-ubuntu
-MSSQL_SUPPORTED       ?= $(MSSQL_VERSION)
+MSSQL_VERSION         ?= 2019-latest
+MSSQL_SUPPORTED       ?= 2017-latest $(MSSQL_VERSION)
 PROJECT               ?= upper_mssql_$(MSSQL_VERSION)
 
 DB_HOST               ?= 127.0.0.1


### PR DESCRIPTION
This optimization got lost at some point, I'm just re-adding it. This PR will make add `LIMIT 1` to `One()` queries, which makes sense because we only want one result.