### PR TITLE
docs: fix paging typo

### DIFF
--- a/result.go
+++ b/result.go
@@ -115,7 +115,7 @@ type Result interface {
 	Paginate(pageSize uint) Result
 
 	// Page makes the result set return results only from the page identified by
-	// pageNumber. Page numbering starts from 0.
+	// pageNumber. Page numbering starts from 1.
 	//
 	// Example:
 	//


### PR DESCRIPTION
I was getting ~an error~ unexpected result paginating (postgres) using `.Page(0)`, so I suspect this is a typo in the docs? The page always starts at 1.

If you'd like I can open an issue and describe the issue I was facing.