### PR TITLE
Add AnyOf and NotAnyOf

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,9 +29,5 @@ jobs:
           echo "DB_HOST=127.0.0.1" >> $GITHUB_ENV
           echo "UPPER_DB_LOG=ERROR" >> $GITHUB_ENV
 
-      - name: Get requisites
-        run: |
-          go get -v modernc.org/ql/ql
-
       - name: Execute main task
         run: make ${{ matrix.target }}

--- a/adapter/mysql/template_test.go
+++ b/adapter/mysql/template_test.go
@@ -161,6 +161,11 @@ func TestTemplateSelect(t *testing.T) {
 			"SELECT * FROM `artist` WHERE (`id` IN ($1, $2) AND `name` LIKE $3)",
 			b.SelectFrom("artist").Where(db.Cond{"name LIKE": "%foo", "id": db.In(1, 2)}).String(),
 		)
+
+		assert.Equal(
+			"SELECT * FROM `artist` WHERE (`id` IN ($1, $2) AND `name` LIKE $3)",
+			b.SelectFrom("artist").Where(db.Cond{"name LIKE": "%foo", "id": db.AnyOf([]int{1, 2})}).String(),
+		)
 	}
 }
 

--- a/comparison.go
+++ b/comparison.go
@@ -68,8 +68,18 @@ func In(value ...interface{}) *Comparison {
 	return &Comparison{adapter.NewComparisonOperator(adapter.ComparisonOperatorIn, toInterfaceArray(value))}
 }
 
+// AnyOf is a comparison that means: is any of the values of the slice.
+func AnyOf(value interface{}) *Comparison {
+	return &Comparison{adapter.NewComparisonOperator(adapter.ComparisonOperatorIn, toInterfaceArray(value))}
+}
+
 // NotIn is a comparison that means: is none of the values.
 func NotIn(value ...interface{}) *Comparison {
+	return &Comparison{adapter.NewComparisonOperator(adapter.ComparisonOperatorNotIn, toInterfaceArray(value))}
+}
+
+// NotAnyOf is a comparison that means: is none of the values of the slice.
+func NotAnyOf(value interface{}) *Comparison {
 	return &Comparison{adapter.NewComparisonOperator(adapter.ComparisonOperatorNotIn, toInterfaceArray(value))}
 }
 


### PR DESCRIPTION
This PR adds `db.AnyOf` and `db.NotAnyOf`, which work like `db.In` and `db.NotIn`, except they accept a slice of any type.