### PR TITLE
Fix sqlite.New panic

### DIFF
--- a/adapter/sqlite/sqlite_test.go
+++ b/adapter/sqlite/sqlite_test.go
@@ -1,0 +1,55 @@
+package sqlite
+
+import (
+	"path/filepath"
+	"testing"
+
+	"database/sql"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/upper/db/v4/internal/testsuite"
+)
+
+type AdapterTests struct {
+	testsuite.Suite
+}
+
+func (s *AdapterTests) SetupSuite() {
+	s.Helper = &Helper{}
+}
+
+func (s *AdapterTests) Test_Issue633_OpenSession() {
+	sess, err := Open(settings)
+	s.NoError(err)
+	defer sess.Close()
+
+	absoluteName, _ := filepath.Abs(settings.Database)
+	s.Equal(absoluteName, sess.Name())
+}
+
+func (s *AdapterTests) Test_Issue633_NewAdapterWithFile() {
+	sqldb, err := sql.Open("sqlite3", settings.Database)
+	s.NoError(err)
+
+	sess, err := New(sqldb)
+	s.NoError(err)
+	defer sess.Close()
+
+	absoluteName, _ := filepath.Abs(settings.Database)
+	s.Equal(absoluteName, sess.Name())
+}
+
+func (s *AdapterTests) Test_Issue633_NewAdapterWithMemory() {
+	sqldb, err := sql.Open("sqlite3", ":memory:")
+	s.NoError(err)
+
+	sess, err := New(sqldb)
+	s.NoError(err)
+	defer sess.Close()
+
+	s.Equal("main", sess.Name())
+}
+
+func TestAdapter(t *testing.T) {
+	suite.Run(t, &AdapterTests{})
+}


### PR DESCRIPTION
Hi!

When using `sqlite.New(sqldb)` to create db session, `sess.ConnectionURL()` is `nil`. Therefore a nil-pointer panic throwed.

I'm using `PRAGMA database_list` to get database name, [here is the document about it](https://www.sqlite.org/pragma.html#pragma_database_list) .

Fix #633 