### PR TITLE
Update default sslmode

### DIFF
--- a/adapter/cockroachdb/connection_pgx.go
+++ b/adapter/cockroachdb/connection_pgx.go
@@ -1,3 +1,4 @@
+//go:build !pq
 // +build !pq
 
 // Copyright (c) 2012-present The upper.io/db authors. All rights reserved.
@@ -49,7 +50,7 @@ func (c ConnectionURL) String() (s string) {
 				host = "127.0.0.1"
 			}
 			if port == "" {
-				port = "5432"
+				port = "26257"
 			}
 			u = append(u, "host="+escaper.Replace(host))
 			u = append(u, "port="+escaper.Replace(port))
@@ -75,9 +76,9 @@ func (c ConnectionURL) String() (s string) {
 		c.Options = map[string]string{}
 	}
 
-	// If not present, SSL mode is assumed disabled.
+	// If not present, SSL mode is assumed enabled.
 	if sslMode, ok := c.Options["sslmode"]; !ok || sslMode == "" {
-		c.Options["sslmode"] = "disable"
+		c.Options["sslmode"] = "prefer"
 	}
 
 	// Disabled by default

--- a/adapter/cockroachdb/connection_pgx.go
+++ b/adapter/cockroachdb/connection_pgx.go
@@ -76,7 +76,7 @@ func (c ConnectionURL) String() (s string) {
 		c.Options = map[string]string{}
 	}
 
-	// If not present, SSL mode is assumed enabled.
+	// If not present, SSL mode is assumed "prefer".
 	if sslMode, ok := c.Options["sslmode"]; !ok || sslMode == "" {
 		c.Options["sslmode"] = "prefer"
 	}

--- a/adapter/cockroachdb/connection_pgx_test.go
+++ b/adapter/cockroachdb/connection_pgx_test.go
@@ -1,3 +1,4 @@
+//go:build !pq
 // +build !pq
 
 // Copyright (c) 2012-present The upper.io/db authors. All rights reserved.
@@ -37,27 +38,27 @@ func TestConnectionURL(t *testing.T) {
 
 	// Adding a host with port.
 	c.Host = "localhost:1234"
-	assert.Equal(t, "host=localhost port=1234 sslmode=disable statement_cache_capacity=0", c.String())
+	assert.Equal(t, "host=localhost port=1234 sslmode=prefer statement_cache_capacity=0", c.String())
 
 	// Adding a host.
 	c.Host = "localhost"
-	assert.Equal(t, "host=localhost sslmode=disable statement_cache_capacity=0", c.String())
+	assert.Equal(t, "host=localhost sslmode=prefer statement_cache_capacity=0", c.String())
 
 	// Adding a username.
 	c.User = "Anakin"
-	assert.Equal(t, `host=localhost sslmode=disable statement_cache_capacity=0 user=Anakin`, c.String())
+	assert.Equal(t, `host=localhost sslmode=prefer statement_cache_capacity=0 user=Anakin`, c.String())
 
 	// Adding a password with special characters.
 	c.Password = "Some Sort of ' Password"
-	assert.Equal(t, `host=localhost password=Some\ Sort\ of\ \'\ Password sslmode=disable statement_cache_capacity=0 user=Anakin`, c.String())
+	assert.Equal(t, `host=localhost password=Some\ Sort\ of\ \'\ Password sslmode=prefer statement_cache_capacity=0 user=Anakin`, c.String())
 
 	// Adding a port.
 	c.Host = "localhost:1234"
-	assert.Equal(t, `host=localhost password=Some\ Sort\ of\ \'\ Password port=1234 sslmode=disable statement_cache_capacity=0 user=Anakin`, c.String())
+	assert.Equal(t, `host=localhost password=Some\ Sort\ of\ \'\ Password port=1234 sslmode=prefer statement_cache_capacity=0 user=Anakin`, c.String())
 
 	// Adding a database.
 	c.Database = "MyDatabase"
-	assert.Equal(t, `dbname=MyDatabase host=localhost password=Some\ Sort\ of\ \'\ Password port=1234 sslmode=disable statement_cache_capacity=0 user=Anakin`, c.String())
+	assert.Equal(t, `dbname=MyDatabase host=localhost password=Some\ Sort\ of\ \'\ Password port=1234 sslmode=prefer statement_cache_capacity=0 user=Anakin`, c.String())
 
 	// Adding options.
 	c.Options = map[string]string{

--- a/adapter/cockroachdb/connection_pq.go
+++ b/adapter/cockroachdb/connection_pq.go
@@ -76,7 +76,7 @@ func (c ConnectionURL) String() (s string) {
 		c.Options = map[string]string{}
 	}
 
-	// If not present, SSL mode is assumed disabled.
+	// If not present, SSL mode is assumed "prefer".
 	if sslMode, ok := c.Options["sslmode"]; !ok || sslMode == "" {
 		c.Options["sslmode"] = "prefer"
 	}

--- a/adapter/cockroachdb/connection_pq.go
+++ b/adapter/cockroachdb/connection_pq.go
@@ -1,3 +1,4 @@
+//go:build pq
 // +build pq
 
 // Copyright (c) 2012-present The upper.io/db authors. All rights reserved.
@@ -49,7 +50,7 @@ func (c ConnectionURL) String() (s string) {
 				host = "127.0.0.1"
 			}
 			if port == "" {
-				port = "5432"
+				port = "26257"
 			}
 			u = append(u, "host="+escaper.Replace(host))
 			u = append(u, "port="+escaper.Replace(port))
@@ -77,7 +78,7 @@ func (c ConnectionURL) String() (s string) {
 
 	// If not present, SSL mode is assumed disabled.
 	if sslMode, ok := c.Options["sslmode"]; !ok || sslMode == "" {
-		c.Options["sslmode"] = "disable"
+		c.Options["sslmode"] = "prefer"
 	}
 
 	for k, v := range c.Options {

--- a/adapter/cockroachdb/connection_pq_test.go
+++ b/adapter/cockroachdb/connection_pq_test.go
@@ -1,3 +1,4 @@
+//go:build pq
 // +build pq
 
 // Copyright (c) 2012-present The upper.io/db authors. All rights reserved.
@@ -37,27 +38,27 @@ func TestConnectionURL(t *testing.T) {
 
 	// Adding a host with port.
 	c.Host = "localhost:1234"
-	assert.Equal(t, "host=localhost port=1234 sslmode=disable", c.String())
+	assert.Equal(t, "host=localhost port=1234 sslmode=prefer", c.String())
 
 	// Adding a host.
 	c.Host = "localhost"
-	assert.Equal(t, "host=localhost sslmode=disable", c.String())
+	assert.Equal(t, "host=localhost sslmode=prefer", c.String())
 
 	// Adding a username.
 	c.User = "Anakin"
-	assert.Equal(t, `host=localhost sslmode=disable user=Anakin`, c.String())
+	assert.Equal(t, `host=localhost sslmode=prefer user=Anakin`, c.String())
 
 	// Adding a password with special characters.
 	c.Password = "Some Sort of ' Password"
-	assert.Equal(t, `host=localhost password=Some\ Sort\ of\ \'\ Password sslmode=disable user=Anakin`, c.String())
+	assert.Equal(t, `host=localhost password=Some\ Sort\ of\ \'\ Password sslmode=prefer user=Anakin`, c.String())
 
 	// Adding a port.
 	c.Host = "localhost:1234"
-	assert.Equal(t, `host=localhost password=Some\ Sort\ of\ \'\ Password port=1234 sslmode=disable user=Anakin`, c.String())
+	assert.Equal(t, `host=localhost password=Some\ Sort\ of\ \'\ Password port=1234 sslmode=prefer user=Anakin`, c.String())
 
 	// Adding a database.
 	c.Database = "MyDatabase"
-	assert.Equal(t, `dbname=MyDatabase host=localhost password=Some\ Sort\ of\ \'\ Password port=1234 sslmode=disable user=Anakin`, c.String())
+	assert.Equal(t, `dbname=MyDatabase host=localhost password=Some\ Sort\ of\ \'\ Password port=1234 sslmode=prefer user=Anakin`, c.String())
 
 	// Adding options.
 	c.Options = map[string]string{

--- a/adapter/postgresql/connection_pgx.go
+++ b/adapter/postgresql/connection_pgx.go
@@ -1,3 +1,4 @@
+//go:build !pq
 // +build !pq
 
 package postgresql
@@ -75,9 +76,9 @@ func (c ConnectionURL) String() (s string) {
 		c.Options = map[string]string{}
 	}
 
-	// If not present, SSL mode is assumed disabled.
+	// If not present, SSL mode is assumed "prefer".
 	if sslMode, ok := c.Options["sslmode"]; !ok || sslMode == "" {
-		c.Options["sslmode"] = "disable"
+		c.Options["sslmode"] = "prefer"
 	}
 
 	// Disabled by default

--- a/adapter/postgresql/connection_pgx_test.go
+++ b/adapter/postgresql/connection_pgx_test.go
@@ -1,3 +1,4 @@
+//go:build !pq
 // +build !pq
 
 // Copyright (c) 2012-present The upper.io/db authors. All rights reserved.
@@ -37,27 +38,27 @@ func TestConnectionURL(t *testing.T) {
 
 	// Adding a host with port.
 	c.Host = "localhost:1234"
-	assert.Equal(t, "host=localhost port=1234 sslmode=disable statement_cache_capacity=0", c.String())
+	assert.Equal(t, "host=localhost port=1234 sslmode=prefer statement_cache_capacity=0", c.String())
 
 	// Adding a host.
 	c.Host = "localhost"
-	assert.Equal(t, "host=localhost sslmode=disable statement_cache_capacity=0", c.String())
+	assert.Equal(t, "host=localhost sslmode=prefer statement_cache_capacity=0", c.String())
 
 	// Adding a username.
 	c.User = "Anakin"
-	assert.Equal(t, `host=localhost sslmode=disable statement_cache_capacity=0 user=Anakin`, c.String())
+	assert.Equal(t, `host=localhost sslmode=prefer statement_cache_capacity=0 user=Anakin`, c.String())
 
 	// Adding a password with special characters.
 	c.Password = "Some Sort of ' Password"
-	assert.Equal(t, `host=localhost password=Some\ Sort\ of\ \'\ Password sslmode=disable statement_cache_capacity=0 user=Anakin`, c.String())
+	assert.Equal(t, `host=localhost password=Some\ Sort\ of\ \'\ Password sslmode=prefer statement_cache_capacity=0 user=Anakin`, c.String())
 
 	// Adding a port.
 	c.Host = "localhost:1234"
-	assert.Equal(t, `host=localhost password=Some\ Sort\ of\ \'\ Password port=1234 sslmode=disable statement_cache_capacity=0 user=Anakin`, c.String())
+	assert.Equal(t, `host=localhost password=Some\ Sort\ of\ \'\ Password port=1234 sslmode=prefer statement_cache_capacity=0 user=Anakin`, c.String())
 
 	// Adding a database.
 	c.Database = "MyDatabase"
-	assert.Equal(t, `dbname=MyDatabase host=localhost password=Some\ Sort\ of\ \'\ Password port=1234 sslmode=disable statement_cache_capacity=0 user=Anakin`, c.String())
+	assert.Equal(t, `dbname=MyDatabase host=localhost password=Some\ Sort\ of\ \'\ Password port=1234 sslmode=prefer statement_cache_capacity=0 user=Anakin`, c.String())
 
 	// Adding options.
 	c.Options = map[string]string{

--- a/adapter/postgresql/connection_pq.go
+++ b/adapter/postgresql/connection_pq.go
@@ -1,3 +1,4 @@
+//go:build pq
 // +build pq
 
 // Copyright (c) 2012-present The upper.io/db authors. All rights reserved.
@@ -75,9 +76,9 @@ func (c ConnectionURL) String() (s string) {
 		c.Options = map[string]string{}
 	}
 
-	// If not present, SSL mode is assumed disabled.
+	// If not present, SSL mode is assumed "prefer".
 	if sslMode, ok := c.Options["sslmode"]; !ok || sslMode == "" {
-		c.Options["sslmode"] = "disable"
+		c.Options["sslmode"] = "prefer"
 	}
 
 	for k, v := range c.Options {

--- a/adapter/postgresql/connection_pq_test.go
+++ b/adapter/postgresql/connection_pq_test.go
@@ -1,3 +1,4 @@
+//go:build pq
 // +build pq
 
 // Copyright (c) 2012-present The upper.io/db authors. All rights reserved.
@@ -37,27 +38,27 @@ func TestConnectionURL(t *testing.T) {
 
 	// Adding a host with port.
 	c.Host = "localhost:1234"
-	assert.Equal(t, "host=localhost port=1234 sslmode=disable", c.String())
+	assert.Equal(t, "host=localhost port=1234 sslmode=prefer", c.String())
 
 	// Adding a host.
 	c.Host = "localhost"
-	assert.Equal(t, "host=localhost sslmode=disable", c.String())
+	assert.Equal(t, "host=localhost sslmode=prefer", c.String())
 
 	// Adding a username.
 	c.User = "Anakin"
-	assert.Equal(t, `host=localhost sslmode=disable user=Anakin`, c.String())
+	assert.Equal(t, `host=localhost sslmode=prefer user=Anakin`, c.String())
 
 	// Adding a password with special characters.
 	c.Password = "Some Sort of ' Password"
-	assert.Equal(t, `host=localhost password=Some\ Sort\ of\ \'\ Password sslmode=disable user=Anakin`, c.String())
+	assert.Equal(t, `host=localhost password=Some\ Sort\ of\ \'\ Password sslmode=prefer user=Anakin`, c.String())
 
 	// Adding a port.
 	c.Host = "localhost:1234"
-	assert.Equal(t, `host=localhost password=Some\ Sort\ of\ \'\ Password port=1234 sslmode=disable user=Anakin`, c.String())
+	assert.Equal(t, `host=localhost password=Some\ Sort\ of\ \'\ Password port=1234 sslmode=prefer user=Anakin`, c.String())
 
 	// Adding a database.
 	c.Database = "MyDatabase"
-	assert.Equal(t, `dbname=MyDatabase host=localhost password=Some\ Sort\ of\ \'\ Password port=1234 sslmode=disable user=Anakin`, c.String())
+	assert.Equal(t, `dbname=MyDatabase host=localhost password=Some\ Sort\ of\ \'\ Password port=1234 sslmode=prefer user=Anakin`, c.String())
 
 	// Adding options.
 	c.Options = map[string]string{


### PR DESCRIPTION
Set default sslmode to `prefer` to use encryption if available.