### PR TITLE
fix panic on json.RawMessage parse

### DIFF
--- a/internal/sqlbuilder/convert.go
+++ b/internal/sqlbuilder/convert.go
@@ -57,7 +57,7 @@ func toInterfaceArguments(value interface{}) (args []interface{}, isSlice bool) 
 
 		// Byte slice gets transformed into a string.
 		if v.Type().Elem().Kind() == reflect.Uint8 {
-			return []interface{}{string(value.([]byte))}, false
+			return []interface{}{string(v.Bytes())}, false
 		}
 
 		total = v.Len()


### PR DESCRIPTION
If we use this struct

```
type Thread struct {
	ID                     string          `db:"id" json:"id"`
	Corresponds   json.RawMessage `db:"correspondents" json:"correspondents"`
}
```

Insert panics because  json.RawMessage is alias for []byte but interface can't be casted to it