### PR TITLE
Cockroach delete limit

### DIFF
--- a/adapter/cockroachdb/template.go
+++ b/adapter/cockroachdb/template.go
@@ -123,6 +123,9 @@ const (
     DELETE
       FROM {{.Table | compile}}
       {{.Where | compile}}
+      {{if .Limit}}
+        LIMIT {{.Limit}}
+      {{end}}
   `
 	adapterUpdateLayout = `
     UPDATE

--- a/adapter/cockroachdb/template_test.go
+++ b/adapter/cockroachdb/template_test.go
@@ -259,4 +259,9 @@ func TestTemplateDelete(t *testing.T) {
 		`DELETE FROM "artist" WHERE (id > 5)`,
 		b.DeleteFrom("artist").Where("id > 5").String(),
 	)
+
+	assert.Equal(
+		`DELETE FROM "artist" WHERE (id > 5) LIMIT 10`,
+		b.DeleteFrom("artist").Where("id > 5").Limit(10).String(),
+	)
 }


### PR DESCRIPTION
Added `Limit` support to Delete template for CockroachDB - it is very sensitive to bulk delete operations and care must be taken to not bring the node down: https://www.cockroachlabs.com/docs/stable/bulk-delete-data

CC: @xiam maybe you could let this in so others could benefit from the fix? Thanks!