### PR TITLE
Avoid treating byte-slices as Slices.

### DIFF
--- a/adapter/mysql/database.go
+++ b/adapter/mysql/database.go
@@ -73,6 +73,12 @@ func (*database) Collections(sess sqladapter.Session) (collections []string, err
 
 func (d *database) ConvertValue(in interface{}) interface{} {
 	switch v := in.(type) {
+	case *[]uint8:
+		return v
+
+	case []uint8:
+		return &v
+
 	case *map[string]interface{}:
 		return (*JSONMap)(v)
 


### PR DESCRIPTION
Don't wrap byte-slices as JSON. This seems to fix a regression caused by https://github.com/upper/db/commit/a6ed3911af80a19f87b1408a2b7626b431fc4532#diff-f5192cd3f0d513df75fe48612bfb73b960650e0ab8b9100d71d17bf4a0e87572